### PR TITLE
[DOC]: Comprehensive Documentation for Glyph CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp/
 .env
+glyph

--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ Glyph is a command-line template engine designed to **accelerate the start of yo
 - **Maintain consistency across different projects by using the same foundations.**
 - **Explore and utilize templates shared by the community or your team.**
 
-**Installation Guide**
+### Installation Guide
 
 **Clone the repository**
 
 ```sh
-git clone [https://github.com/DanteDev2102/Glyph.git](https://github.com/DanteDev2102/Glyph.git) ~/Glyph
+git clone https://github.com/DanteDev2102/Glyph.git ~/Glyph
+```
+
+**Compile this repository with go build**
+
+```sh
+go build -o glyph ~/Glyph/cmd/app/main.go
 ```
 
 **Execute the Installation Script**

--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ sh ~/Glyph/install.sh
 **Restart your terminal and YOU'RE READY TO USE GLYPH!**
 
 Thank you for pointing out the missing section. It's crucial for the installation instructions to be complete.
+
+**Documentation:**
+
+- [**create:**](/docs/create.md)
+
+- [**init**](/docs/init.md)
+
+- [**rm**](/docs/rm.md)
+
+- [**set**](/docs/update.md)

--- a/config/docs.go
+++ b/config/docs.go
@@ -1,0 +1,91 @@
+package config
+
+const (
+	CreateUse         string = "create --repo <repository-url> --name <template-name> --summary <short-description> --description <long-description>"
+	CreateSummary     string = "Create new template command"
+	CreateDescription string = `
+Creates a new, user-defined command within Glyph that leverages remote Git repositories as scaffolding templates for project initialization.
+
+This command allows you to define a new subcommand that, when invoked, will clone a specified Git repository. This cloned repository then serves as the foundation for creating new projects with a consistent and pre-configured structure.
+
+You will need to provide the following information when creating a new command:
+
+--name -n: The name of the new Glyph subcommand you wish to create. This will be used with the init command (e.g., glyph init <your-new-command>).
+--repo -r: The URL of the Git repository containing the scaffolding template.
+--branch -b (optional): The specific branch of the repository to clone. If not specified, the default branch will be used.
+--tag -t (optional): A specific tag within the repository to checkout. If both --branch and --tag are provided, --tag will take precedence.
+--summary -s (optional): A short, one-line description of the template.
+--description -d (optional): A more detailed explanation of what this template provides.
+
+The configuration for this new command will be stored in the ~/.config/Glyph/repositories.toml file, making it available for subsequent use with the init command.
+
+Example:
+	glyph create --name fiber-template --repo git@github.com/MyUser/fiber-template.git
+	`
+
+	InitUse         string = "init <template-name> <destination-directory>"
+	InitSummary     string = "Initializes a new project using a custom template."
+	InitDescription string = `
+This command clones a pre-configured Git repository into the specified
+destination directory, based on a template you've previously defined
+using the 'create' command.
+
+Arguments:
+	<template_name> 		The name of the custom template to use. Glyph
+    				will look up the repository details for this name
+                  			in its configuration.
+
+	<destination_directory> The path where you want to clone the template
+	                      	repository and initialize your new project. This
+	                      	directory will be created if it doesn't exist.
+
+Examples:
+	glyph init node-basic my-new-app
+	glyph init react-ui ~/Projects/frontend
+
+Notes:
+	Before using 'init', you must first define your custom templates using
+	the 'create' command. Glyph reads the template configurations from
+	~/.config/Glyph/repositories.toml.
+	`
+
+	RmUse                = "rm <template-name>"
+	RmSummary     string = "The delete command reads the Glyph configuration file "
+	RmDescription string = `
+Deletes a custom template configuration from Glyph.
+
+This command removes the specified template entry from the
+~/.config/Glyph/repositories.toml configuration file. Once deleted,
+the template will no longer be available for use with the 'init' command.
+
+<template-name> is the name of the custom template you wish to remove.
+
+Examples:
+	glyph delete my-old-template
+	`
+
+	SetUse         string = "set <old-template-name>"
+	SetSummary     string = "Modify an existing custom template configuration."
+	SetDescription string = `
+Modifies an existing custom template configuration.
+
+This command allows you to change the settings of a previously created
+template in the ~/.config/Glyph/repositories.toml file. You can update
+properties like the repository URL, branch, tag, summary, description,
+and even rename the template.
+
+<old-template-name> is the current name of the template you want to update.
+
+Flags:
+	-b, --branch string      The new branch name for the template.
+	-d, --description string The new detailed description for the template.
+	-n, --name string        The new name for the template.
+	-r, --repo string        The new URL of the Git repository for the template.
+	-s, --summary string     The new short description for the template.
+	-t, --tag string         The new tag name for the template.
+
+Examples:
+	glyph update existing-template --repo [https://new-repo.com/project.git](https://new-repo.com/project.git)
+	glyph update my-old-name --name my-new-name --summary "Updated description"
+	`
+)

--- a/config/repositories.toml
+++ b/config/repositories.toml
@@ -1,5 +1,5 @@
 [example]
 repo = "https://github.com/DanteDev2102/Glyph.git"
-branch = "development"
+branch = "develop"
 description = "this is a sample command"
 summary = "this is a sample command"

--- a/docs/create.md
+++ b/docs/create.md
@@ -1,0 +1,38 @@
+# Create Command
+
+The `create` command allows you to define new custom commands within Glyph, enabling the cloning of a remote repository to be used as a scaffolding template for project initialization. The configuration for these templates is stored in the `~/.config/Glyph/repositories.toml` file.
+
+**Usage:**
+
+```sh
+glyph create --name <template_name> --repo <repository_url> [--branch <branch_name>] [--tag <tag_name>] [--summary "<short_description>"] [--description "<detailed_description>"]
+```
+
+**Options:**
+
+- `--name`, `-n`: _(Required)_ A unique name for your template. This will be used as the subcommand with `glyph init`.
+- `--repo`, `-r`: _(Required)_ The URL of the Git repository containing the scaffolding template.
+- `--branch`, `-b`: _(Optional)_ The specific branch of the repository to clone. Defaults to the repository's default branch.
+- `--tag`, `-t`: _(Optional)_ A specific tag within the repository to checkout. If both `--branch` and `--tag` are provided, `--tag` takes precedence.
+- `--summary`, `-s`: _(Optional)_ A short, one-line description of the template.
+- `--description`, `-d`: _(Optional)_ A more detailed explanation of what this template provides.
+
+**Examples:**
+
+1.  **Creating a basic Node.js template:**
+
+```sh
+glyph create --name node-basic --repo https://github.com/expressjs/express-generator --summary "Basic Express.js application" --description "A simple Express.js application structure."
+```
+
+2.  **Creating a specific branch template for a React project:**
+
+```sh
+glyph create --name react-feature --repo https://github.com/facebook/create-react-app --branch feature-ui --summary "React app with the feature-ui branch" --description "A React application initialized from the 'feature-ui' branch."
+```
+
+3. **Creating a template using a specific tag:**
+
+```sh
+glyph create --name vue-legacy --repo https://github.com/vuejs/vue-cli --tag v3.0.0 --summary "Vue CLI v3.0.0 template" --description "A Vue.js project initialized with Vue CLI version 3.0.0."
+```

--- a/docs/init.md
+++ b/docs/init.md
@@ -1,0 +1,28 @@
+# Init Command
+
+The `init` command leverages the custom templates configured in the ~/.config/Glyph/repositories.toml file. For each defined template, a corresponding subcommand is dynamically created under init, allowing you to quickly clone and initialize new projects based on your custom scaffolding.
+
+**Usage:**
+
+```sh
+glyph init <template_name> <destination_directory>
+```
+
+**Arguments:**
+
+<template_name>: The name of the custom template you want to use (as defined with the create command).
+<destination_directory>: The path where you want to clone the template repository and initialize your new project.
+
+**Examples:**
+
+Initializing a new Node.js project using the node-basic template:
+
+```sh
+glyph init node-basic my-new-node-app
+```
+
+Initializing a React project using the react-ui template:
+
+```sh
+glyph init react-ui frontend
+```

--- a/docs/rm.md
+++ b/docs/rm.md
@@ -1,0 +1,17 @@
+# RM Command
+
+The delete command reads the ~/.config/Glyph/repositories.toml file to identify and remove a previously created custom template based on its name.
+
+**Usage:**
+
+```sh
+glyph rm <template_name>
+```
+
+**Example:**
+
+To delete the node-basic template:
+
+```sh
+glyph rm node-basic
+```

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,33 @@
+# Set Command
+
+The set command reads the ~/.config/Glyph/repositories.toml file to find and modify an existing custom template. You can change any of its configured keys, including the name.
+
+**Usage:**
+
+```sh
+glyph set <old_template_name> [--name <new_template_name>] [--repo <new_repository_url>] [--branch <new_branch_name>] [--tag <new_tag_name>] [--summary "<new_short_description>"] [--description "<new_detailed_description>"]
+```
+
+**Options:**
+
+<old_template_name>: (Required) The current name of the template you want to update.
+--name, -n: (Optional) The new name for the template.
+--repo, -r: (Optional) The new URL of the Git repository.
+--branch, -b: (Optional) The new branch name.
+--tag, -t: (Optional) The new tag name.
+--summary, -s: (Optional) The new short description.
+--description, -d: (Optional) The new detailed description.
+
+**Example:**
+
+To update the repository URL of the node-basic template:
+
+```sh
+glyph set node-basic --repo https://github.com/nodejs/node-starter
+```
+
+To rename the react-feature template to react-ui and update its description:
+
+```sh
+glyph update react-feature --name react-ui --description "React application with the latest UI features."
+```

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
 )
@@ -10,12 +11,15 @@ import (
 // CreateCmd adds the "create" command to the CLI root command.
 func (cli *Base) CreateCmd() {
 	cli.Root.AddCommand(&cobra.Command{
-		Use:   "create --repo [repository url] --name [template name] --short [short description your command] --long [long description your command]",
-		Short: "example",
-		Long:  "example",
+		Use:   config.CreateUse,
+		Short: config.CreateSummary,
+		Long:  config.CreateDescription,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(name) == 0 || len(repo) == 0 {
+			if name == "" || repo == "" {
 				fmt.Println("name and repo flags required")
+				return
+			} else if branch != "" && tag != "" {
+				fmt.Println("Use only branch or only tag for create new project template")
 				return
 			}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
 )
@@ -24,25 +25,28 @@ func chargeTemplates(initCmd *cobra.Command, commands *[]parser.Command) {
 					return
 				}
 
+				if len(branch) > 0 && len(tag) > 0 {
+					fmt.Println("use only branch or only tag for init project")
+					return
+				}
+
 				if len(strings.TrimSpace(args[0])) <= 3 {
 					fmt.Println("Not valid path")
 					return
 				}
 
+				var detail string
+
 				arg := []string{"clone", "--depth=1", command.Repo, args[0]}
 
-				detail := command.Tag
-
-				if len(detail) == 0 {
-					detail = command.Branch
-				}
-
-				if len(detail) == 0 {
-					detail = branch
-				}
-
-				if len(detail) == 0 {
+				if tag != "" {
 					detail = tag
+				} else if branch != "" {
+					detail = branch
+				} else if command.Tag != "" {
+					detail = command.Tag
+				} else if command.Branch != "" {
+					detail = command.Branch
 				}
 
 				if len(detail) > 0 {
@@ -52,6 +56,7 @@ func chargeTemplates(initCmd *cobra.Command, commands *[]parser.Command) {
 				execute := exec.Command("git", arg...)
 				err := execute.Run()
 				if err != nil {
+					fmt.Println(err)
 					return
 				}
 
@@ -60,8 +65,15 @@ func chargeTemplates(initCmd *cobra.Command, commands *[]parser.Command) {
 				err = execute.Run()
 				if err != nil {
 					fmt.Println(err)
+					return
 				}
 
+				execute = exec.Command("git", "init", args[0])
+				err = execute.Run()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
 			},
 		})
 	}
@@ -70,9 +82,9 @@ func chargeTemplates(initCmd *cobra.Command, commands *[]parser.Command) {
 // InitCmd initializes the CLI with the "init" command.
 func (cli *Base) InitCmd() {
 	initCmd := &cobra.Command{
-		Use:   "init [template name]",
-		Short: "example",
-		Long:  "example",
+		Use:   config.InitUse,
+		Short: config.InitSummary,
+		Long:  config.InitDescription,
 	}
 
 	chargeTemplates(initCmd, &cli.Conf.Commmands)

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -1,15 +1,17 @@
 package cli
 
 import (
+	"github.com/DanteDev2102/Glyph/config"
 	"github.com/spf13/cobra"
 )
 
 // DeleteCmd adds the "rm" command to the CLI, allowing users to delete a configuration section by name.
 func (cli *Base) DeleteCmd() {
 	cli.Root.AddCommand(&cobra.Command{
-		Use:   "rm [name template]",
-		Short: "example",
-		Long:  "example",
+		Use:   config.RmUse,
+		Short: config.RmSummary,
+		Long:  config.RmDescription,
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cli.Conf.DeleteSection(args[0])
 		},

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
 )
@@ -8,9 +9,10 @@ import (
 // UpdateCmd adds the "set" command to the CLI, allowing users to configure templates.
 func (cli *Base) UpdateCmd() {
 	cli.Root.AddCommand(&cobra.Command{
-		Use:   "set [name template] --repo [repository url] --name [name template] --branch [branch] --tag [tag] --summary [summary] --description [description]",
-		Short: "example",
-		Long:  "example",
+		Use:   config.SetUse,
+		Short: config.SetSummary,
+		Long:  config.SetDescription,
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -19,30 +19,34 @@ type Template struct {
 }
 
 func (p *Parser) Write(tmpl *Template) {
+	for _, value := range p.Commmands {
+		if value.Key == tmpl.Name {
+			fmt.Println("This command already exist")
+			return
+		}
+	}
+
 	var builder strings.Builder
 	builder.Grow(len(p.Content) + len(tmpl.Name) + len(tmpl.Repo) + 50)
 
-	builder.WriteString("\n")
-	builder.WriteString(string(p.Content))
-	builder.WriteString("\n")
-	builder.WriteString(fmt.Sprintf("[%s]", tmpl.Name))
-	builder.WriteString("\n")
-	builder.WriteString(fmt.Sprintf("repo = \"%s\"\n", tmpl.Repo))
+	builder.WriteString(
+		fmt.Sprintf("%s\n[%s]\nrepo = \"%s\"\n", string(p.Content), tmpl.Name, tmpl.Repo),
+	)
 
-	if len(tmpl.Branch) > 0 {
-		builder.WriteString(fmt.Sprintf("branch = \"%s\"\n", tmpl.Branch))
+	fields := []struct {
+		key   string
+		value string
+	}{
+		{"branch", tmpl.Branch},
+		{"tag", tmpl.Tag},
+		{"summary", tmpl.Summary},
+		{"description", tmpl.Description},
 	}
 
-	if len(tmpl.Tag) > 0 {
-		builder.WriteString(fmt.Sprintf("tag = \"%s\"\n", tmpl.Tag))
-	}
-
-	if len(tmpl.Summary) > 0 {
-		builder.WriteString(fmt.Sprintf("short = \"%s\"\n", tmpl.Summary))
-	}
-
-	if len(tmpl.Description) > 0 {
-		builder.WriteString(fmt.Sprintf("long = \"%s\"\n", tmpl.Branch))
+	for _, field := range fields {
+		if field.value != "" {
+			builder.WriteString(fmt.Sprintf("%s = \"%s\"\n", field.key, field.value))
+		}
 	}
 
 	builder.WriteString("\n")
@@ -58,7 +62,7 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
-	var config map[string]interface{}
+	var config map[string]map[string]string
 
 	err := toml.Unmarshal(p.Content, &config)
 	if err != nil {
@@ -72,7 +76,17 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 		return
 	}
 
+	if tmpl.Branch != "" && tmpl.Tag != "" {
+		fmt.Println("Only branch or tag flag")
+		return
+	}
+
 	var newValues = make(map[string]string)
+	newValues = map[string]string{
+		"repo":        config[name]["repo"],
+		"summary":     config[name]["summary"],
+		"description": config[name]["description"],
+	}
 
 	if len(tmpl.Repo) > 0 {
 		newValues["repo"] = tmpl.Repo
@@ -97,6 +111,8 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	if len(tmpl.Name) > 0 {
 		delete(config, name)
 		config[tmpl.Name] = newValues
+	} else {
+		config[name] = newValues
 	}
 
 	data, er := toml.Marshal(config)


### PR DESCRIPTION
This pull request introduces a comprehensive documentation update for the Glyph command-line interface (CLI). The documentation aims to provide users with a clear understanding of Glyph's purpose, installation process, and detailed usage of its core features.

**Key Changes and Additions:**

1.  **Project Overview:**
    * Added a concise introduction explaining Glyph's core functionality as a CLI template engine designed to accelerate project bootstrapping.
    * Highlighted the key benefits of using Glyph, such as rapid project initiation, consistency across projects, and leveraging shared templates.

2.  **Installation Guide:**
    * Provided step-by-step instructions for cloning the Glyph repository from GitHub.
    * Detailed the execution of the installation script (`install.sh`) for macOS and Linux users.
    * Included a clear indication that users need to restart their terminal after installation to use Glyph.

3.  **Features Documentation:**
    * Organized the core functionalities of Glyph under a dedicated "docs" section.

    * **Create New Template (`create`):**
        * Explained the purpose of the `create` command: defining new custom commands for scaffolding.
        * Provided the command usage syntax, including all available options (`--name`, `--repo`, `--branch`, `--tag`, `--summary`, `--description`) with their descriptions and necessity.
        * Included detailed examples demonstrating how to create templates for various scenarios (basic Node.js, specific branch React, tagged Vue CLI).

    * **Delete Custom Template (`rm`):**
        * Described the functionality of the `rm` command for removing custom template configurations.
        * Provided the simple usage syntax and a clear example of deleting a template.

    * **Update Template (`set`):**
        * Explained how the `update` command allows modification of existing template configurations.
        * Detailed the usage syntax, including the required `<old_template_name>` argument and all modifiable flags (`--name`, `--repo`, `--branch`, `--tag`, `--summary`, `--description`).
        * Included illustrative examples of updating the repository URL and renaming a template with an updated description.

    * **Initialize Project with Custom Template (`init`):**
        * Clearly explained the core function of the `init` command: leveraging configured templates to start new projects.
        * Provided the usage syntax with the required `<template_name>` and `<destination_directory>` arguments.
        * Included comprehensive examples showing how to initialize projects using different templates and specifying the destination directory.
        * Detailed the behavior of the `init` command, including reading the configuration, retrieving template details, and using `git clone`.
