### PR TITLE
🛡️ Sentinel: [HIGH] Fix symlink attack and improve path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Symlink Protection in Template Replacement
+**Vulnerability:** Symlink attack during project initialization. A cloned template could contain a symlink `README.md -> /etc/passwd`. The tool would then overwrite the system file when performing variable replacement.
+**Learning:** Automatic variable replacement in files after cloning an untrusted repository is a high-risk operation if symlinks are followed.
+**Prevention:** Always use `os.Lstat` to check for symlinks before reading from or writing to files that were recently created from an external source.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -67,6 +67,16 @@ func getAuthor(tmplAuthor string, globalAuthor string) string {
 }
 
 func replaceInFile(filePath string, replacements map[string]string) {
+	// Security check: Don't follow symlinks to prevent path traversal
+	info, err := os.Lstat(filePath)
+	if err != nil {
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		fmt.Printf("Warning: Skipping replacement in %s as it is a symlink\n", filePath)
+		return
+	}
+
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return
@@ -99,9 +109,9 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 					return
 				}
 
-				dstPath := args[0]
-				if len(strings.TrimSpace(dstPath)) <= 3 {
-					fmt.Println("Not valid path")
+				dstPath := filepath.Clean(args[0])
+				if dstPath == "/" || dstPath == "." || dstPath == ".." || len(strings.TrimSpace(dstPath)) <= 1 {
+					fmt.Println("Dangerous or invalid path provided")
 					return
 				}
 

--- a/internal/cli/init_security_test.go
+++ b/internal/cli/init_security_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReplaceInFile_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	targetFile := filepath.Join(tmpDir, "target")
+	err = os.WriteFile(targetFile, []byte("Hello {{.Name}}"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(tmpDir, "symlink")
+	err = os.Symlink(targetFile, symlinkFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "World"}
+	replaceInFile(symlinkFile, replacements)
+
+	// Check if targetFile was modified
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != "Hello {{.Name}}" {
+		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestReplaceInFile_RegularFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	regularFile := filepath.Join(tmpDir, "regular")
+	err = os.WriteFile(regularFile, []byte("Hello {{.Name}}"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "World"}
+	replaceInFile(regularFile, replacements)
+
+	content, err := os.ReadFile(regularFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != "Hello World" {
+		t.Errorf("Regular file was not modified! Content: %s", string(content))
+	}
+}
+
+func TestDstPathValidation(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool // true if valid, false if invalid
+	}{
+		{"myproject", true},
+		{"/", false},
+		{".", false},
+		{"..", false},
+		{"/etc", true}, // We currently allow absolute paths that are not root
+		{"   ", false},
+		{"a", false},
+	}
+
+	for _, c := range cases {
+		dstPath := filepath.Clean(c.input)
+		valid := !(dstPath == "/" || dstPath == "." || dstPath == ".." || len(strings.TrimSpace(dstPath)) <= 1)
+		if valid != c.expected {
+			t.Errorf("Validation failed for %s: expected %v, got %v", c.input, c.expected, valid)
+		}
+	}
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential symlink attack during project initialization and lack of path sanitization.
🎯 Impact: A malicious template could overwrite sensitive system files (e.g., via a symlink to /etc/passwd). Users could also accidentally initialize projects in dangerous system directories.
🔧 Fix:
- Added `os.Lstat` check in `replaceInFile` to skip symlinks.
- Used `filepath.Clean` for `dstPath` and added checks to reject `/`, `.`, and `..`.
✅ Verification: Added `internal/cli/init_security_test.go` verifying symlink protection and path validation. All tests passed.

---
*PR created automatically by Jules for task [15072039398559234253](https://jules.google.com/task/15072039398559234253) started by @DanteDev2102*