### PR TITLE
🛡️ Sentinel: [HIGH] Fix symlink vulnerability in file copy operations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Symlink attack during project initialization. A cloned template could contain a symlink `README.md -> /etc/passwd`. The tool would then overwrite the system file when performing variable replacement.
 **Learning:** Automatic variable replacement in files after cloning an untrusted repository is a high-risk operation if symlinks are followed.
 **Prevention:** Always use `os.Lstat` to check for symlinks before reading from or writing to files that were recently created from an external source.
+
+## 2025-01-30 - Comprehensive Symlink Protection
+**Vulnerability:** Partial symlink protection only covered variable replacement, leaving file copy operations (`copyFile`, `copyDir`) vulnerable to overwriting arbitrary files via pre-existing symlinks at the destination.
+**Learning:** Security fixes must be applied to all relevant code paths. Protecting only one stage of a multi-stage file operation (like project initialization) leaves other stages exposed to similar attacks.
+**Prevention:** Audit all functions that perform file I/O (especially those using `os.Create` or `os.Open` for writing) and ensure they verify the destination isn't a symbolic link when targeting untrusted or recently created directories.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -32,6 +32,12 @@ func copyDir(src string, dst string) error {
 			return os.MkdirAll(target, info.Mode())
 		}
 
+		// Security check: Don't follow symlinks at the destination
+		targetInfo, err := os.Lstat(target)
+		if err == nil && targetInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to copy to %s: destination is a symlink", target)
+		}
+
 		srcFile, err := os.Open(path)
 		if err != nil {
 			return err
@@ -199,6 +205,12 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Don't follow symlinks at the destination
+	info, err := os.Lstat(dst)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to copy to %s: destination is a symlink", dst)
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err

--- a/internal/cli/init_security_test.go
+++ b/internal/cli/init_security_test.go
@@ -88,3 +88,100 @@ func TestDstPathValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyFile_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	targetFile := filepath.Join(tmpDir, "target")
+	err = os.WriteFile(targetFile, []byte("Original Content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "symlink_to_target")
+	err = os.Symlink(targetFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(tmpDir, "source")
+	err = os.WriteFile(srcFile, []byte("Malicious Content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = copyFile(srcFile, dstFile)
+	if err == nil {
+		t.Error("Expected error when copying to a symlink destination, but got nil")
+	} else if !strings.Contains(err.Error(), "destination is a symlink") {
+		t.Errorf("Expected error containing 'destination is a symlink', but got: %v", err)
+	}
+
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) == "Malicious Content" {
+		t.Errorf("Security Vulnerability: copyFile followed symlink and modified target file!")
+	}
+}
+
+func TestCopyDir_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create source directory with a file
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.MkdirAll(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("Source Content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create destination directory with a symlink pointing elsewhere
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = os.MkdirAll(dstDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(targetFile, []byte("Secret Content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink in dst that points to secret
+	err = os.Symlink(targetFile, filepath.Join(dstDir, "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to copy src to dst
+	err = copyDir(srcDir, dstDir)
+	if err == nil {
+		t.Error("Expected error when copying to a directory containing a symlink, but got nil")
+	} else if !strings.Contains(err.Error(), "destination is a symlink") {
+		t.Errorf("Expected error containing 'destination is a symlink', but got: %v", err)
+	}
+
+	// Check if secret file was NOT modified
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) == "Source Content" {
+		t.Errorf("Security Vulnerability: copyDir followed symlink and modified target file!")
+	}
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Symbolic link attack in file copy operations.
🎯 Impact: An attacker could pre-plant symbolic links at the destination path, causing the application to overwrite sensitive system or user files during project initialization.
🔧 Fix: Implemented destination path verification using `os.Lstat` in `copyFile` and `copyDir`. The application now refuses to write to a path if it is a symbolic link.
✅ Verification: New test cases `TestCopyFile_Symlink` and `TestCopyDir_Symlink` in `internal/cli/init_security_test.go` confirm that the vulnerability is mitigated and the application fails securely when a symlink is encountered.

---
*PR created automatically by Jules for task [9374651107754894388](https://jules.google.com/task/9374651107754894388) started by @DanteDev2102*