### PR TITLE
🛡️ Sentinel: [HIGH] Harden copy operations against symlink attacks

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -21,12 +21,24 @@ func copyDir(src string, dst string) error {
 			return err
 		}
 
+		// Skip symlinks in source to prevent information disclosure
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
 		}
 
 		target := filepath.Join(dst, rel)
+
+		// Security check: Don't follow symlinks at destination
+		if targetInfo, err := os.Lstat(target); err == nil {
+			if targetInfo.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("security error: destination path %s is a symlink", target)
+			}
+		}
 
 		if info.IsDir() {
 			return os.MkdirAll(target, info.Mode())
@@ -199,6 +211,21 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Don't follow symlinks at source or destination
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("security error: source %s is a symlink", src)
+	}
+
+	if dstInfo, err := os.Lstat(dst); err == nil {
+		if dstInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("security error: destination %s is a symlink", dst)
+		}
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err

--- a/internal/cli/init_security_test.go
+++ b/internal/cli/init_security_test.go
@@ -88,3 +88,61 @@ func TestDstPathValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyFile_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-copyfile-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	os.WriteFile(srcFile, []byte("New Content"), 0644)
+
+	targetFile := filepath.Join(tmpDir, "target")
+	os.WriteFile(targetFile, []byte("Original Content"), 0644)
+
+	symlinkFile := filepath.Join(tmpDir, "symlink")
+	os.Symlink(targetFile, symlinkFile)
+
+	err = copyFile(srcFile, symlinkFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when destination is a symlink")
+	}
+
+	content, _ := os.ReadFile(targetFile)
+	if string(content) != "Original Content" {
+		t.Errorf("Target file was modified through symlink!")
+	}
+}
+
+func TestCopyDir_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-copydir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	os.Mkdir(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "file1"), []byte("New Content"), 0644)
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	os.Mkdir(dstDir, 0755)
+
+	targetFile := filepath.Join(tmpDir, "target")
+	os.WriteFile(targetFile, []byte("Original Content"), 0644)
+
+	symlinkFile := filepath.Join(dstDir, "file1")
+	os.Symlink(targetFile, symlinkFile)
+
+	err = copyDir(srcDir, dstDir)
+	if err == nil {
+		t.Errorf("copyDir should have failed when destination contains a symlink")
+	}
+
+	content, _ := os.ReadFile(targetFile)
+	if string(content) != "Original Content" {
+		t.Errorf("Target file was modified through symlink!")
+	}
+}


### PR DESCRIPTION
This PR hardens the `copyFile` and `copyDir` functions in `internal/cli/init.go` against symbolic link attacks.

Previously, these functions followed symlinks, which could be exploited by a malicious template to overwrite sensitive system files or disclose their contents.

Changes:
- In `copyFile`, added `os.Lstat` checks for both source and destination. It now returns an error if either is a symbolic link.
- In `copyDir`, added `os.Lstat` checks for both source and destination of each entry. It skips symbolic links in the source and returns an error if a destination path is already a symbolic link.
- Added `TestCopyFile_Symlink` and `TestCopyDir_Symlink` to `internal/cli/init_security_test.go` to ensure protection.

These changes follow the principle of defense in depth and ensure that Glyph fails securely when encountering unexpected symbolic links.

---
*PR created automatically by Jules for task [18320636907950204145](https://jules.google.com/task/18320636907950204145) started by @DanteDev2102*