### PR TITLE
🛡️ Sentinel: [HIGH] Harden project initialization against symlink attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Symlink attack during project initialization. A cloned template could contain a symlink `README.md -> /etc/passwd`. The tool would then overwrite the system file when performing variable replacement.
 **Learning:** Automatic variable replacement in files after cloning an untrusted repository is a high-risk operation if symlinks are followed.
 **Prevention:** Always use `os.Lstat` to check for symlinks before reading from or writing to files that were recently created from an external source.
+
+## 2025-05-15 - Expanded Symlink Protection in Init Operations
+**Vulnerability:** Symlink attacks during project initialization in copyDir, copyFile, and destination path handling. An attacker could use symlinks to leak sensitive files from the host or overwrite system files.
+**Learning:** Hardening only the file replacement logic is insufficient if the initial copy or destination validation also follows symlinks.
+**Prevention:** Consistently use os.Lstat to check all file/directory targets and sources involved in template extraction and initialization. Skip symlinks in sources and reject them in destinations.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -21,12 +21,22 @@ func copyDir(src string, dst string) error {
 			return err
 		}
 
+		// Security: skip symlinks in source to prevent information disclosure
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
 		}
 
 		target := filepath.Join(dst, rel)
+
+		// Security: check if destination already exists and is a symlink
+		if dstInfo, err := os.Lstat(target); err == nil && dstInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("security error: destination path %s is a symbolic link", target)
+		}
 
 		if info.IsDir() {
 			return os.MkdirAll(target, info.Mode())
@@ -115,6 +125,12 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 					return
 				}
 
+				// Security check: ensure dstPath itself is not a symlink
+				if info, err := os.Lstat(dstPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+					fmt.Println("Security error: destination path is a symbolic link")
+					return
+				}
+
 				var err error
 				if command.LocalPath != "" {
 					err = copyDir(command.LocalPath, dstPath)
@@ -199,6 +215,11 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security: check if destination already exists and is a symlink
+	if dstInfo, err := os.Lstat(dst); err == nil && dstInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("security error: destination path %s is a symbolic link", dst)
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err

--- a/internal/cli/security_harden_test.go
+++ b/internal/cli/security_harden_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyFile_SymlinkOverwrite(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-security-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = os.Symlink(secretFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(tmpDir, "src")
+	err = os.WriteFile(srcFile, []byte("NOT SECRET"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return an error now
+	err = copyFile(srcFile, dstFile)
+	if err == nil {
+		t.Error("Expected error when copying to a symlink destination, but got nil")
+	} else if !strings.Contains(err.Error(), "symbolic link") {
+		t.Errorf("Expected security error about symbolic link, got: %v", err)
+	}
+
+	// Check if secretFile was NOT overwritten
+	content, err := os.ReadFile(secretFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != "TOP SECRET" {
+		t.Errorf("Secret file was overwritten through symlink! Content: %s", string(content))
+	}
+}
+
+func TestCopyDir_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-security-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(tmpDir, "srcDir")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(srcDir, "leak")
+	err = os.Symlink(secretFile, symlinkFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dstDir")
+
+	// Should skip the symlink
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatalf("copyDir failed: %v", err)
+	}
+
+	// Check if leaked file does NOT exist in dstDir
+	leakedFile := filepath.Join(dstDir, "leak")
+	if _, err := os.Stat(leakedFile); !os.IsNotExist(err) {
+		t.Errorf("Symlink was followed or copied to destination!")
+	}
+}
+
+func TestCopyDir_SymlinkDestination(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-security-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretDir := filepath.Join(tmpDir, "secretDir")
+	err = os.Mkdir(secretDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dstDir")
+	err = os.Mkdir(dstDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink in dstDir pointing to secretDir
+	symlinkSubDir := filepath.Join(dstDir, "subdir")
+	err = os.Symlink(secretDir, symlinkSubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(tmpDir, "srcDir")
+	err = os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(srcDir, "subdir", "evil.txt"), []byte("EVIL"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return an error now
+	err = copyDir(srcDir, dstDir)
+	if err == nil {
+		t.Error("Expected error when copying to a symlink destination, but got nil")
+	} else if !strings.Contains(err.Error(), "symbolic link") {
+		t.Errorf("Expected security error about symbolic link, got: %v", err)
+	}
+
+	// Check if evil.txt was NOT created in secretDir
+	evilFile := filepath.Join(secretDir, "evil.txt")
+	if _, err := os.Stat(evilFile); err == nil {
+		t.Errorf("File was created in secret directory through symlink! %s", evilFile)
+	}
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Symlink attacks during project initialization. The `copyDir` and `copyFile` functions followed symlinks, which could allow a malicious template to read sensitive host files (Information Disclosure) or trick the tool into overwriting arbitrary host files (Arbitrary File Overwrite).
🎯 Impact: An attacker could potentially steal secrets (e.g., SSH keys, credentials) or compromise the host system by overwriting critical files if a user is tricked into using a malicious template.
🔧 Fix: Hardened `copyDir`, `copyFile`, and the destination path validation in `chargeTemplates` by using `os.Lstat` to detect and reject/skip symbolic links.
✅ Verification: Added comprehensive regression tests in `internal/cli/security_harden_test.go` that verify both source-leak prevention and destination-overwrite prevention. Ran all repository tests and confirmed they pass.

---
*PR created automatically by Jules for task [11056712731571286464](https://jules.google.com/task/11056712731571286464) started by @DanteDev2102*