### PR TITLE
🛡️ Sentinel: [HIGH] Harden file operations against symlink attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Symlink attack during project initialization. A cloned template could contain a symlink `README.md -> /etc/passwd`. The tool would then overwrite the system file when performing variable replacement.
 **Learning:** Automatic variable replacement in files after cloning an untrusted repository is a high-risk operation if symlinks are followed.
 **Prevention:** Always use `os.Lstat` to check for symlinks before reading from or writing to files that were recently created from an external source.
+
+## 2025-05-14 - Enhanced Symlink Protection in File Operations
+**Vulnerability:** Information disclosure and arbitrary file overwrite during template copying. `copyDir` and `copyFile` followed symlinks at both source and destination.
+**Learning:** Hardening individual file operations is not enough; all paths in a recursive copy or file creation must be validated to prevent jumping out of the intended directory via symlinks.
+**Prevention:** Skip symlinks at the source to prevent reading unauthorized files, and reject symlinks at the destination to prevent overwriting existing files outside the target directory. Use os.Lstat for all existence/mode checks.

--- a/internal/cli/copy_security_test.go
+++ b/internal/cli/copy_security_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(srcDir, "link")
+	err = os.Symlink(secretFile, symlinkFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copiedFile := filepath.Join(dstDir, "link")
+	if _, err := os.Stat(copiedFile); !os.IsNotExist(err) {
+		t.Errorf("copyDir should have skipped symlink at source, but file exists at destination")
+	}
+}
+
+func TestCopyDir_SymlinkDestination(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(srcDir, "file"), []byte("new content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetFile := filepath.Join(tmpDir, "target")
+	err = os.WriteFile(targetFile, []byte("original content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = os.Mkdir(dstDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Symlink(targetFile, filepath.Join(dstDir, "file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = copyDir(srcDir, dstDir)
+	if err == nil {
+		t.Errorf("copyDir should have failed when destination is a symlink")
+	}
+
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "original content" {
+		t.Errorf("copyDir followed symlink at destination and overwrote target file!")
+	}
+}
+
+func TestCopyFile_SymlinkDestination(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	err = os.WriteFile(srcFile, []byte("new license"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetFile := filepath.Join(tmpDir, "target")
+	err = os.WriteFile(targetFile, []byte("original content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst_link")
+	err = os.Symlink(targetFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = copyFile(srcFile, dstFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when destination is a symlink")
+	}
+
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "original content" {
+		t.Errorf("copyFile followed symlink at destination and overwrote target file!")
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -21,12 +21,24 @@ func copyDir(src string, dst string) error {
 			return err
 		}
 
+		// Security check: Skip symbolic links at the source to prevent information disclosure
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
 			return err
 		}
 
 		target := filepath.Join(dst, rel)
+
+		// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
+		if info, err := os.Lstat(target); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("destination %s is a symbolic link", target)
+			}
+		}
 
 		if info.IsDir() {
 			return os.MkdirAll(target, info.Mode())
@@ -115,6 +127,14 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 					return
 				}
 
+				// Security check: Don't allow initialization into a symbolic link
+				if info, err := os.Lstat(dstPath); err == nil {
+					if info.Mode()&os.ModeSymlink != 0 {
+						fmt.Printf("Destination path %s is a symbolic link, which is not allowed for security reasons.\n", dstPath)
+						return
+					}
+				}
+
 				var err error
 				if command.LocalPath != "" {
 					err = copyDir(command.LocalPath, dstPath)
@@ -199,6 +219,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
+	if info, err := os.Lstat(dst); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("destination %s is a symbolic link", dst)
+		}
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR enhances the security of the project initialization process by hardening file and directory copying operations against symbolic link attacks.

### 🚨 Severity: HIGH

### 💡 Vulnerability:
The `copyDir` and `copyFile` functions were following symbolic links at both the source and destination.
1. **Source:** A malicious template could contain a symlink to a sensitive file (e.g., `/etc/passwd`). Glyph would then copy the content of that file into the new project, leading to information disclosure.
2. **Destination:** If the user-provided destination path already contained a symlink to a sensitive system file, Glyph could overwrite it, leading to arbitrary file overwrite.

### 🔧 Fix:
- Modified `copyDir` to use `os.Lstat` and skip any symbolic links found in the source directory.
- Modified `copyDir` and `copyFile` to check the destination path with `os.Lstat` and return an error if it is a symbolic link.
- Added a check in the `init` command handler (`chargeTemplates`) to prevent initializing a project into a path that is a symbolic link.

### ✅ Verification:
- Created new security tests in `internal/cli/copy_security_test.go` that specifically verify these scenarios.
- Ran `go test ./internal/cli/...` and confirmed all tests pass.
- Verified that regular file and directory copying still works as expected.

---
*PR created automatically by Jules for task [1757544301382379839](https://jules.google.com/task/1757544301382379839) started by @DanteDev2102*