### PR TITLE
🛡️ Sentinel: [High] Fix symlink vulnerability in configuration parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Information disclosure and arbitrary file overwrite during template copying. `copyDir` and `copyFile` followed symlinks at both source and destination.
 **Learning:** Hardening individual file operations is not enough; all paths in a recursive copy or file creation must be validated to prevent jumping out of the intended directory via symlinks.
 **Prevention:** Skip symlinks at the source to prevent reading unauthorized files, and reject symlinks at the destination to prevent overwriting existing files outside the target directory. Use os.Lstat for all existence/mode checks.
+
+## 2026-02-17 - Symlink Protection in Configuration Parser
+**Vulnerability:** Symlink attack on the global configuration file. An attacker could pre-create the configuration file as a symlink to a sensitive file, causing the tool to overwrite it when saving templates.
+**Learning:** Hardening the CLI's project initialization is insufficient if the configuration persistence layer remains vulnerable to the same class of attacks.
+**Prevention:** Always use `os.Lstat` to verify that a file is not a symbolic link before performing read or write operations on shared or predictable configuration paths.

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -31,7 +30,7 @@ func (p *Parser) DeleteSection(name string) {
 		return
 	}
 
-	err = os.WriteFile(p.File, data, 0644)
+	err = p.safeWrite(data)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -1,5 +1,10 @@
 package parser
 
+import (
+	"fmt"
+	"os"
+)
+
 // Config holds global configuration for Glyph.
 type Config struct {
 	Author string `toml:"author"`
@@ -34,4 +39,15 @@ type IParser interface {
 	ExtractCommands()
 	Refresh()
 	DeleteSection()
+}
+
+// safeWrite checks if the target file is a symlink before writing data to it.
+func (p *Parser) safeWrite(data []byte) error {
+	if info, err := os.Lstat(p.File); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("security error: %s is a symbolic link", p.File)
+		}
+	}
+
+	return os.WriteFile(p.File, data, 0644)
 }

--- a/internal/parser/read.go
+++ b/internal/parser/read.go
@@ -9,6 +9,12 @@ import (
 
 func (p *Parser) ensureContentRead() error {
 	if !p.ContentRead {
+		if info, err := os.Lstat(p.File); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("security error: %s is a symbolic link", p.File)
+			}
+		}
+
 		templates, err := os.ReadFile(p.File)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -1,0 +1,50 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWrite_Symlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	targetFile := filepath.Join(tmpDir, "sensitive_file")
+	err = os.WriteFile(targetFile, []byte("SENSITIVE DATA"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink from configPath to targetFile
+	err = os.Symlink(targetFile, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+
+	tmpl := &Template{
+		Name: "test-template",
+		Repo: "https://github.com/test/repo",
+	}
+
+	// This should NOT overwrite targetFile if we have symlink protection
+	p.Write(tmpl)
+
+	// Check if targetFile was modified
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != "SENSITIVE DATA" {
+		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -61,7 +61,7 @@ func (p *Parser) Write(tmpl *Template) {
 	dir := filepath.Dir(p.File)
 	os.MkdirAll(dir, 0755)
 
-	if err := os.WriteFile(p.File, data, 0644); err != nil {
+	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -143,7 +143,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	dir := filepath.Dir(p.File)
 	os.MkdirAll(dir, 0755)
 
-	err = os.WriteFile(p.File, data, 0644)
+	err = p.safeWrite(data)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
🚨 Severity: High
💡 Vulnerability: The configuration parser followed symbolic links when reading, writing, or deleting the global template configuration file.
🎯 Impact: An attacker could pre-create the configuration file as a symlink to a sensitive system file, potentially causing the tool to read from or overwrite it.
🔧 Fix: Implemented os.Lstat checks in internal/parser to ensure the configuration file is not a symbolic link before performing I/O.
✅ Verification: Added a new security test internal/parser/security_test.go that confirms symlinks are rejected. All tests passed.

---
*PR created automatically by Jules for task [4048849122577577647](https://jules.google.com/task/4048849122577577647) started by @DanteDev2102*