### PR TITLE
🛡️ Sentinel: [Enhancement] Add SSH passphrase support and auth input validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Symlink attack on the global configuration file. An attacker could pre-create the configuration file as a symlink to a sensitive file, causing the tool to overwrite it when saving templates.
 **Learning:** Hardening the CLI's project initialization is insufficient if the configuration persistence layer remains vulnerable to the same class of attacks.
 **Prevention:** Always use `os.Lstat` to verify that a file is not a symbolic link before performing read or write operations on shared or predictable configuration paths.
+
+## 2025-05-15 - Support for Encrypted SSH Keys
+**Vulnerability:** Weak security practice due to lack of passphrase support. The tool previously only supported unencrypted SSH keys, which could encourage users to use less secure authentication methods.
+**Learning:** Hardcoding an empty passphrase in SSH authentication logic significantly reduces the security posture of the tool by making encrypted keys unusable.
+**Prevention:** Always provide an option for users to enter a passphrase when using SSH key authentication, and ensure it is collected securely using masked inputs.

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -1,8 +1,10 @@
 package gitutils
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -77,13 +79,28 @@ func RequestAuth() (transport.AuthMethod, error) {
 		prompt := promptui.Prompt{
 			Label:   "Path to SSH Key",
 			Default: home + "/.ssh/id_rsa",
+			Validate: func(input string) error {
+				if _, err := os.Stat(input); os.IsNotExist(err) {
+					return errors.New("ssh key file does not exist")
+				}
+				return nil
+			},
 		}
 		keyPath, err := prompt.Run()
 		if err != nil {
 			return nil, err
 		}
 
-		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, "")
+		promptPass := promptui.Prompt{
+			Label: "SSH Key Passphrase (optional)",
+			Mask:  '*',
+		}
+		passphrase, err := promptPass.Run()
+		if err != nil {
+			return nil, err
+		}
+
+		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, passphrase)
 		if err != nil {
 			return nil, err
 		}
@@ -91,6 +108,12 @@ func RequestAuth() (transport.AuthMethod, error) {
 	} else {
 		promptUser := promptui.Prompt{
 			Label: "Username",
+			Validate: func(input string) error {
+				if len(strings.TrimSpace(input)) == 0 {
+					return errors.New("username cannot be empty")
+				}
+				return nil
+			},
 		}
 		username, err := promptUser.Run()
 		if err != nil {
@@ -100,6 +123,12 @@ func RequestAuth() (transport.AuthMethod, error) {
 		promptPass := promptui.Prompt{
 			Label: "Token/Password",
 			Mask:  '*',
+			Validate: func(input string) error {
+				if len(strings.TrimSpace(input)) == 0 {
+					return errors.New("token/password cannot be empty")
+				}
+				return nil
+			},
 		}
 		password, err := promptPass.Run()
 		if err != nil {


### PR DESCRIPTION
This PR enhances the security and robustness of Glyph's authentication logic. By adding support for SSH key passphrases, we enable users to use encrypted private keys, which is a security best practice. Additionally, adding input validation for usernames, tokens, and file paths prevents common misconfigurations and improves the overall reliability of the tool.

---
*PR created automatically by Jules for task [1233794367416900569](https://jules.google.com/task/1233794367416900569) started by @DanteDev2102*