### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden git authentication process

### DIFF
--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -77,20 +77,43 @@ func RequestAuth() (transport.AuthMethod, error) {
 		prompt := promptui.Prompt{
 			Label:   "Path to SSH Key",
 			Default: home + "/.ssh/id_rsa",
+			Validate: func(input string) error {
+				if _, err := os.Stat(input); os.IsNotExist(err) {
+					return fmt.Errorf("SSH key file does not exist")
+				}
+				return nil
+			},
 		}
 		keyPath, err := prompt.Run()
 		if err != nil {
 			return nil, err
 		}
 
-		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, "")
+		promptPass := promptui.Prompt{
+			Label: "SSH Key Passphrase (optional)",
+			Mask:  '*',
+		}
+		passphrase, err := promptPass.Run()
+		if err != nil {
+			return nil, err
+		}
+
+		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, passphrase)
 		if err != nil {
 			return nil, err
 		}
 		return publicKeys, nil
 	} else {
+		validate := func(input string) error {
+			if len(input) == 0 {
+				return fmt.Errorf("this field cannot be empty")
+			}
+			return nil
+		}
+
 		promptUser := promptui.Prompt{
-			Label: "Username",
+			Label:    "Username",
+			Validate: validate,
 		}
 		username, err := promptUser.Run()
 		if err != nil {
@@ -98,8 +121,9 @@ func RequestAuth() (transport.AuthMethod, error) {
 		}
 
 		promptPass := promptui.Prompt{
-			Label: "Token/Password",
-			Mask:  '*',
+			Label:    "Token/Password",
+			Mask:     '*',
+			Validate: validate,
 		}
 		password, err := promptPass.Run()
 		if err != nil {


### PR DESCRIPTION
Improved the security of the git authentication process in `internal/gitutils/git.go`:
- Added support for passphrase-protected SSH keys by adding a masked prompt for an optional passphrase and updating `ssh.NewPublicKeysFromFile` to use it.
- Added non-empty validation for username and password prompts to ensure credentials are provided before attempting authentication.
- Added validation for the SSH key path prompt to verify the file exists before processing, improving both security and UX.
- Masked sensitive inputs (passwords, tokens, and passphrases) using `promptui.Prompt`'s `Mask` feature to prevent them from being visible in the terminal.

These changes align with defense-in-depth principles and the "fail securely" philosophy by ensuring only valid and, where applicable, encrypted credentials are used.

---
*PR created automatically by Jules for task [3081515195217062048](https://jules.google.com/task/3081515195217062048) started by @DanteDev2102*