### PR TITLE
🛡️ Sentinel: Harden git authentication process

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Symlink attack on the global configuration file. An attacker could pre-create the configuration file as a symlink to a sensitive file, causing the tool to overwrite it when saving templates.
 **Learning:** Hardening the CLI's project initialization is insufficient if the configuration persistence layer remains vulnerable to the same class of attacks.
 **Prevention:** Always use `os.Lstat` to verify that a file is not a symbolic link before performing read or write operations on shared or predictable configuration paths.
+
+## 2026-03-05 - Hardening CLI Authentication Prompts
+**Vulnerability:** Weak input validation and missing support for secure authentication practices (e.g., encrypted SSH keys) in interactive prompts.
+**Learning:** Interactive prompts must be as robust as any other input source. Failing to validate credentials or support best practices like passphrase-protected keys can lead to confusing failures or push users toward less secure methods.
+**Prevention:** Use `promptui.Prompt.Validate` to enforce non-empty inputs and verify file existence (e.g., for SSH keys) early. Always support masked passphrase inputs for sensitive operations instead of assuming unencrypted keys.

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -1,8 +1,10 @@
 package gitutils
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -77,13 +79,28 @@ func RequestAuth() (transport.AuthMethod, error) {
 		prompt := promptui.Prompt{
 			Label:   "Path to SSH Key",
 			Default: home + "/.ssh/id_rsa",
+			Validate: func(input string) error {
+				if _, err := os.Stat(input); os.IsNotExist(err) {
+					return errors.New("ssh key file does not exist")
+				}
+				return nil
+			},
 		}
 		keyPath, err := prompt.Run()
 		if err != nil {
 			return nil, err
 		}
 
-		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, "")
+		promptPass := promptui.Prompt{
+			Label: "Passphrase (leave empty if none)",
+			Mask:  '*',
+		}
+		passphrase, err := promptPass.Run()
+		if err != nil {
+			return nil, err
+		}
+
+		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, passphrase)
 		if err != nil {
 			return nil, err
 		}
@@ -91,6 +108,12 @@ func RequestAuth() (transport.AuthMethod, error) {
 	} else {
 		promptUser := promptui.Prompt{
 			Label: "Username",
+			Validate: func(input string) error {
+				if len(strings.TrimSpace(input)) == 0 {
+					return errors.New("username cannot be empty")
+				}
+				return nil
+			},
 		}
 		username, err := promptUser.Run()
 		if err != nil {
@@ -100,6 +123,12 @@ func RequestAuth() (transport.AuthMethod, error) {
 		promptPass := promptui.Prompt{
 			Label: "Token/Password",
 			Mask:  '*',
+			Validate: func(input string) error {
+				if len(strings.TrimSpace(input)) == 0 {
+					return errors.New("password or token cannot be empty")
+				}
+				return nil
+			},
 		}
 		password, err := promptPass.Run()
 		if err != nil {


### PR DESCRIPTION
Improved the git authentication process in `internal/gitutils/git.go` by:
1. Adding non-empty validation for Username and Token/Password prompts using `promptui.Prompt.Validate`.
2. Adding a file existence check for the SSH key path prompt using `os.Stat`.
3. Adding support for masked SSH key passphrases, allowing the use of encrypted SSH keys.
4. Updated the Sentinel journal with these improvements as a reusable security pattern.

These changes prevent confusing failures and encourage better security practices by supporting passphrase-protected keys.

---
*PR created automatically by Jules for task [4490302867648124956](https://jules.google.com/task/4490302867648124956) started by @DanteDev2102*