### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden authentication and improve error handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Symlink attack on the global configuration file. An attacker could pre-create the configuration file as a symlink to a sensitive file, causing the tool to overwrite it when saving templates.
 **Learning:** Hardening the CLI's project initialization is insufficient if the configuration persistence layer remains vulnerable to the same class of attacks.
 **Prevention:** Always use `os.Lstat` to verify that a file is not a symbolic link before performing read or write operations on shared or predictable configuration paths.
+
+## 2026-03-20 - Credential Validation and Information Disclosure
+**Vulnerability:** Lack of input validation in authentication prompts and information disclosure via stack traces. Users could provide empty credentials or invalid SSH key paths, and configuration errors would trigger a panic, leaking internal details.
+**Learning:** Authentication flows should always validate inputs to fail early and securely. Global initialization in CLI tools must handle errors gracefully instead of panicking to avoid exposing internal state to users.
+**Prevention:** Use validation functions for all user inputs in interactive prompts. Replace `panic` with controlled exits and sanitized error messages in the application's entry points.

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	parser "github.com/DanteDev2102/Glyph/internal/parser"
@@ -44,7 +45,8 @@ func init() {
 
 	err = conf.ExtractCommands()
 	if err != nil {
-		panic(err)
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
 	}
 
 	Cli = &Base{

--- a/internal/gitutils/auth_test.go
+++ b/internal/gitutils/auth_test.go
@@ -1,0 +1,57 @@
+package gitutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateNonEmpty(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantErr bool
+	}{
+		{"user", false},
+		{"  user  ", false},
+		{"", true},
+		{"   ", true},
+	}
+
+	for _, tt := range tests {
+		err := ValidateNonEmpty(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateNonEmpty(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateFileExists(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-auth-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	existingFile := filepath.Join(tmpDir, "exists")
+	err = os.WriteFile(existingFile, []byte("data"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonExistingFile := filepath.Join(tmpDir, "not-exists")
+
+	tests := []struct {
+		path     string
+		wantErr bool
+	}{
+		{existingFile, false},
+		{nonExistingFile, true},
+	}
+
+	for _, tt := range tests {
+		err := ValidateFileExists(tt.path)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateFileExists(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+		}
+	}
+}

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -1,8 +1,10 @@
 package gitutils
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -60,6 +62,22 @@ func ValidateRepo(url string) (transport.AuthMethod, error) {
 	return nil, err
 }
 
+// ValidateNonEmpty ensures that the input is not empty or just whitespace.
+func ValidateNonEmpty(input string) error {
+	if strings.TrimSpace(input) == "" {
+		return errors.New("input cannot be empty")
+	}
+	return nil
+}
+
+// ValidateFileExists ensures that the provided path points to an existing file.
+func ValidateFileExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return errors.New("file does not exist")
+	}
+	return nil
+}
+
 // RequestAuth prompts the user for authentication credentials.
 func RequestAuth() (transport.AuthMethod, error) {
 	prompt := promptui.Select{
@@ -75,22 +93,33 @@ func RequestAuth() (transport.AuthMethod, error) {
 	if result == "SSH Key" {
 		home, _ := os.UserHomeDir()
 		prompt := promptui.Prompt{
-			Label:   "Path to SSH Key",
-			Default: home + "/.ssh/id_rsa",
+			Label:    "Path to SSH Key",
+			Default:  home + "/.ssh/id_rsa",
+			Validate: ValidateFileExists,
 		}
 		keyPath, err := prompt.Run()
 		if err != nil {
 			return nil, err
 		}
 
-		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, "")
+		promptPassphrase := promptui.Prompt{
+			Label: "Passphrase (optional)",
+			Mask:  '*',
+		}
+		passphrase, err := promptPassphrase.Run()
+		if err != nil {
+			return nil, err
+		}
+
+		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyPath, passphrase)
 		if err != nil {
 			return nil, err
 		}
 		return publicKeys, nil
 	} else {
 		promptUser := promptui.Prompt{
-			Label: "Username",
+			Label:    "Username",
+			Validate: ValidateNonEmpty,
 		}
 		username, err := promptUser.Run()
 		if err != nil {
@@ -98,8 +127,9 @@ func RequestAuth() (transport.AuthMethod, error) {
 		}
 
 		promptPass := promptui.Prompt{
-			Label: "Token/Password",
-			Mask:  '*',
+			Label:    "Token/Password",
+			Mask:     '*',
+			Validate: ValidateNonEmpty,
 		}
 		password, err := promptPass.Run()
 		if err != nil {


### PR DESCRIPTION
This PR enhances the security of the Glyph CLI by hardening the authentication flow and improving error handling.

### 🚨 Severity: MEDIUM

### 💡 Vulnerability:
1. **Lack of Input Validation**: The `RequestAuth` function allowed empty usernames and tokens, and did not verify if the SSH key path existed before attempting to use it.
2. **Missing Passphrase Support**: SSH keys with passphrases were not supported (passphrase was hardcoded to empty string).
3. **Information Disclosure**: Using `panic(err)` in the global `init()` function could leak internal stack traces when a security-related error (like a symlink attack on the config file) occurred.

### 🎯 Impact:
- Improved robustness of the authentication process.
- Support for secure, encrypted SSH keys.
- Prevention of internal state leakage during errors.

### 🔧 Fix:
- Extracted validation logic into `ValidateNonEmpty` and `ValidateFileExists`.
- Added a `Passphrase` prompt to the SSH authentication flow.
- Replaced `panic` with `fmt.Printf` and `os.Exit(1)` in `internal/cli/main.go`.

### ✅ Verification:
- Unit tests added in `internal/gitutils/auth_test.go`.
- Verified all tests pass with `go test ./...`.

---
*PR created automatically by Jules for task [15366195570630991149](https://jules.google.com/task/15366195570630991149) started by @DanteDev2102*