### PR TITLE
🛡️ Sentinel: [HIGH] Hardened template names and file operations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Lack of input validation in authentication prompts and information disclosure via stack traces. Users could provide empty credentials or invalid SSH key paths, and configuration errors would trigger a panic, leaking internal details.
 **Learning:** Authentication flows should always validate inputs to fail early and securely. Global initialization in CLI tools must handle errors gracefully instead of panicking to avoid exposing internal state to users.
 **Prevention:** Use validation functions for all user inputs in interactive prompts. Replace `panic` with controlled exits and sanitized error messages in the application's entry points.
+
+## 2024-05-24 - Reserved Keyword and Name Validation
+**Vulnerability:** Global configuration overwrite via template name collision. The tool used the reserved keyword `config` for global settings, but allowed users to create templates with the same name, overwriting or corrupting the global configuration section.
+**Learning:** In applications using a shared name space (like TOML keys or CLI subcommands), reserved keywords must be explicitly validated and rejected in user-controlled inputs.
+**Prevention:** Implement a strict validation function for all user-provided identifiers that rejects reserved keywords and enforces a safe character set (e.g., alphanumeric and basic separators) to prevent logical collisions and injection risks.

--- a/internal/cli/copy_security_test.go
+++ b/internal/cli/copy_security_test.go
@@ -128,3 +128,34 @@ func TestCopyFile_SymlinkDestination(t *testing.T) {
 		t.Errorf("copyFile followed symlink at destination and overwrote target file!")
 	}
 }
+
+func TestCopyFile_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(tmpDir, "link")
+	err = os.Symlink(secretFile, srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+
+	err = copyFile(srcFile, dstFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when source is a symlink")
+	}
+
+	if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+		t.Errorf("copyFile should not have created destination file when source is a symlink")
+	}
+}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -24,6 +24,11 @@ func (cli *Base) CreateCmd() {
 				return
 			}
 
+			if err := parser.ValidateName(name); err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+
 			if repo != "" {
 				_, err := gitutils.ValidateRepo(repo)
 				if err != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -219,6 +219,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Skip symbolic links at the source to prevent information disclosure
+	if info, err := os.Lstat(src); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s is a symbolic link", src)
+		}
+	}
+
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
 	if info, err := os.Lstat(dst); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
@@ -14,6 +16,13 @@ func (cli *Base) UpdateCmd() {
 		Long:  config.SetDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if name != "" {
+				if err := parser.ValidateName(name); err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return
+				}
+			}
+
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,
 				Repo:        repo,

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"os"
+	"regexp"
 )
 
 // Config holds global configuration for Glyph.
@@ -50,4 +51,19 @@ func (p *Parser) safeWrite(data []byte) error {
 	}
 
 	return os.WriteFile(p.File, data, 0644)
+}
+
+// ValidateName ensures the template name is not a reserved keyword and contains only valid characters.
+func ValidateName(name string) error {
+	if name == "config" {
+		return fmt.Errorf("'%s' is a reserved name", name)
+	}
+
+	// Only allow alphanumeric characters, hyphens and underscores to ensure compatibility with CLI and TOML
+	validName := regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
+	if !validName.MatchString(name) {
+		return fmt.Errorf("invalid name '%s': only alphanumeric characters, hyphens, and underscores are allowed", name)
+	}
+
+	return nil
 }

--- a/internal/parser/name_validation_test.go
+++ b/internal/parser/name_validation_test.go
@@ -1,0 +1,31 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"validname", false},
+		{"valid-name", false},
+		{"valid_name", false},
+		{"valid123", false},
+		{"config", true},
+		{"my template", true},
+		{"name!", true},
+		{"", true},
+		{"../name", true},
+		{"/", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateName(tt.name); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses a high-priority logical vulnerability where template names could collide with the global 'config' section in the configuration file, potentially overwriting global settings. It also adds a defense-in-depth measure to `copyFile` to prevent it from following source symbolic links, which could be used for information disclosure.

Changes:
- Added `ValidateName` in `internal/parser/main.go`.
- Integrated `ValidateName` into `internal/cli/create.go` and `internal/cli/update.go`.
- Hardened `copyFile` in `internal/cli/init.go` against source symlink attacks.
- Added `internal/parser/name_validation_test.go`.
- Added `TestCopyFile_SymlinkSource` to `internal/cli/copy_security_test.go`.

---
*PR created automatically by Jules for task [4840837963261870179](https://jules.google.com/task/4840837963261870179) started by @DanteDev2102*