### PR TITLE
🛡️ Sentinel: [HIGH] Prevent information disclosure via source symlinks in copyFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Lack of input validation in authentication prompts and information disclosure via stack traces. Users could provide empty credentials or invalid SSH key paths, and configuration errors would trigger a panic, leaking internal details.
 **Learning:** Authentication flows should always validate inputs to fail early and securely. Global initialization in CLI tools must handle errors gracefully instead of panicking to avoid exposing internal state to users.
 **Prevention:** Use validation functions for all user inputs in interactive prompts. Replace `panic` with controlled exits and sanitized error messages in the application's entry points.
+
+## 2026-04-12 - Information Disclosure via Symlink in copyFile
+**Vulnerability:** Information disclosure during project initialization. The `copyFile` function followed symlinks at the source, allowing an attacker to read sensitive files (e.g., `/etc/passwd`) by providing a symlink as a license or template file.
+**Learning:** Hardening only the destination of a file copy is insufficient; the source must also be checked to prevent unauthorized file access via symbolic links.
+**Prevention:** Always use `os.Lstat` to verify that both source and destination paths are not symbolic links before performing file copy operations.

--- a/internal/cli/copy_security_test.go
+++ b/internal/cli/copy_security_test.go
@@ -128,3 +128,33 @@ func TestCopyFile_SymlinkDestination(t *testing.T) {
 		t.Errorf("copyFile followed symlink at destination and overwrote target file!")
 	}
 }
+
+func TestCopyFile_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(tmpDir, "link")
+	err = os.Symlink(secretFile, symlinkFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = copyFile(symlinkFile, dstFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when source is a symlink")
+	}
+
+	if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+		t.Errorf("copyFile should not have created destination file when source is a symlink")
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -219,6 +219,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Reject symbolic links at the source to prevent information disclosure
+	if info, err := os.Lstat(src); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s is a symbolic link", src)
+		}
+	}
+
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
 	if info, err := os.Lstat(dst); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Prevent information disclosure via source symlinks in copyFile

Vulnerability: Information disclosure during project initialization. The copyFile function followed symlinks at the source, allowing an attacker to read sensitive files (e.g., /etc/passwd) by providing a symlink as a license or template file.

Fix: Added os.Lstat check to verify that the source path is not a symbolic link before opening it for copying.

Verification: Added TestCopyFile_SymlinkSource and verified with go test ./internal/cli/...


---
*PR created automatically by Jules for task [8776895905351884828](https://jules.google.com/task/8776895905351884828) started by @DanteDev2102*