### PR TITLE
🛡️ Sentinel: Harden copyFile against source symlinks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Lack of input validation in authentication prompts and information disclosure via stack traces. Users could provide empty credentials or invalid SSH key paths, and configuration errors would trigger a panic, leaking internal details.
 **Learning:** Authentication flows should always validate inputs to fail early and securely. Global initialization in CLI tools must handle errors gracefully instead of panicking to avoid exposing internal state to users.
 **Prevention:** Use validation functions for all user inputs in interactive prompts. Replace `panic` with controlled exits and sanitized error messages in the application's entry points.
+
+## 2026-04-15 - Incomplete Symlink Hardening in File Operations
+**Vulnerability:** Information disclosure via symlink at source in `copyFile`. While `copyDir` and the destination of `copyFile` were hardened, the source of `copyFile` remained vulnerable.
+**Learning:** Hardening one side of a file operation (destination) or one variant of an operation (`copyDir`) does not guarantee the other is secure. Security audits must verify every path in every I/O function.
+**Prevention:** Always apply symmetric symlink protections to both source and destination in all file copying utilities. Verify hardening with negative tests for both source and destination symlinks.

--- a/internal/cli/copy_security_test.go
+++ b/internal/cli/copy_security_test.go
@@ -128,3 +128,34 @@ func TestCopyFile_SymlinkDestination(t *testing.T) {
 		t.Errorf("copyFile followed symlink at destination and overwrote target file!")
 	}
 }
+
+func TestCopyFile_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkFile := filepath.Join(tmpDir, "link")
+	err = os.Symlink(secretFile, symlinkFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+
+	err = copyFile(symlinkFile, dstFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when source is a symlink")
+	}
+
+	if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+		t.Errorf("copyFile should not have created the destination file when source is a symlink")
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -219,6 +219,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Reject symbolic links at the source to prevent information disclosure
+	if info, err := os.Lstat(src); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s is a symbolic link", src)
+		}
+	}
+
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
 	if info, err := os.Lstat(dst); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {


### PR DESCRIPTION
The `copyFile` function in `internal/cli/init.go` was previously only hardened against symbolic links at the destination. This PR adds a similar check for the source path to prevent information disclosure if the source is a symbolic link to a sensitive file. A new test case has been added to verify this protection.

---
*PR created automatically by Jules for task [11661280524436627722](https://jules.google.com/task/11661280524436627722) started by @DanteDev2102*