### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden file operations and secure config permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Lack of input validation in authentication prompts and information disclosure via stack traces. Users could provide empty credentials or invalid SSH key paths, and configuration errors would trigger a panic, leaking internal details.
 **Learning:** Authentication flows should always validate inputs to fail early and securely. Global initialization in CLI tools must handle errors gracefully instead of panicking to avoid exposing internal state to users.
 **Prevention:** Use validation functions for all user inputs in interactive prompts. Replace `panic` with controlled exits and sanitized error messages in the application's entry points.
+
+## 2026-04-12 - Secure Configuration File Permissions
+**Vulnerability:** Configuration file created with world-readable permissions (0644).
+**Learning:** Default file creation permissions in many languages/environments are overly permissive for configuration files that may contain sensitive user information or preferences.
+**Prevention:** Explicitly set restricted permissions (e.g., 0600) when creating or writing to configuration files to ensure only the owner can access them.

--- a/internal/cli/copy_security_test.go
+++ b/internal/cli/copy_security_test.go
@@ -128,3 +128,34 @@ func TestCopyFile_SymlinkDestination(t *testing.T) {
 		t.Errorf("copyFile followed symlink at destination and overwrote target file!")
 	}
 }
+
+func TestCopyFile_SymlinkSource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	secretFile := filepath.Join(tmpDir, "secret")
+	err = os.WriteFile(secretFile, []byte("TOP SECRET"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(tmpDir, "src_link")
+	err = os.Symlink(secretFile, srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+
+	err = copyFile(srcFile, dstFile)
+	if err == nil {
+		t.Errorf("copyFile should have failed when source is a symlink")
+	}
+
+	if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+		t.Errorf("copyFile should not have created destination file when source is a symlink")
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -219,6 +219,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	// Security check: Reject symbolic links at the source to prevent information disclosure
+	if info, err := os.Lstat(src); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source %s is a symbolic link", src)
+		}
+	}
+
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
 	if info, err := os.Lstat(dst); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,5 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0644)
+	return os.WriteFile(p.File, data, 0600)
 }


### PR DESCRIPTION
This PR addresses two security improvements:
1.  **Source Symlink Protection**: Hardens `copyFile` by adding a check that prevents copying from a symbolic link. This mitigates risks of unintentional information disclosure if a template were to include malicious symlinks.
2.  **Configuration Permission Hardening**: Updates the configuration file writing logic to use `0600` permissions (owner read/write only) instead of `0644`. This ensures that user configuration data is kept private from other users on the same system.

A new test case `TestCopyFile_SymlinkSource` was added to verify the symlink protection. All tests passed.

---
*PR created automatically by Jules for task [647446443540193063](https://jules.google.com/task/647446443540193063) started by @DanteDev2102*