### PR TITLE
🛡️ Sentinel: [MEDIUM] Add template name validation

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -19,7 +19,14 @@ func (cli *Base) CreateCmd() {
 			if name == "" || (repo == "" && localPath == "") {
 				fmt.Println("name and (repo or local) flags required")
 				return
-			} else if branch != "" && tag != "" {
+			}
+
+			if err := parser.ValidateTemplateName(name); err != nil {
+				fmt.Printf("Invalid template name: %v\n", err)
+				return
+			}
+
+			if branch != "" && tag != "" {
 				fmt.Println("Use only branch or only tag for create new project template")
 				return
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
@@ -14,6 +16,13 @@ func (cli *Base) UpdateCmd() {
 		Long:  config.SetDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if name != "" {
+				if err := parser.ValidateTemplateName(name); err != nil {
+					fmt.Printf("Invalid template name: %v\n", err)
+					return
+				}
+			}
+
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,
 				Repo:        repo,

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -1,8 +1,11 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 )
 
 // Config holds global configuration for Glyph.
@@ -39,6 +42,33 @@ type IParser interface {
 	ExtractCommands()
 	Refresh()
 	DeleteSection()
+}
+
+// ValidateTemplateName checks if the provided name is a valid and safe template name.
+func ValidateTemplateName(name string) error {
+	if len(name) == 0 {
+		return errors.New("template name cannot be empty")
+	}
+
+	if len(name) > 50 {
+		return errors.New("template name is too long (max 50 characters)")
+	}
+
+	// Alphanumeric, hyphens, and underscores only
+	validName := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	if !validName.MatchString(name) {
+		return errors.New("template name contains invalid characters (only alphanumeric, hyphens, and underscores allowed)")
+	}
+
+	// Reserved names check
+	reserved := []string{"config", "help", "init", "create", "rm", "set", "list", "glyph"}
+	for _, r := range reserved {
+		if strings.ToLower(name) == r {
+			return fmt.Errorf("'%s' is a reserved name and cannot be used as a template name", name)
+		}
+	}
+
+	return nil
 }
 
 // safeWrite checks if the target file is a symlink before writing data to it.

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -48,3 +48,35 @@ func TestWrite_Symlink(t *testing.T) {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
 	}
 }
+
+func TestValidateTemplateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"valid-name", false},
+		{"ValidName_123", false},
+		{"", true},
+		{"config", true},
+		{"help", true},
+		{"init", true},
+		{"create", true},
+		{"rm", true},
+		{"set", true},
+		{"list", true},
+		{"glyph", true},
+		{"CONFIG", true},
+		{"invalid name", true},
+		{"invalid@name", true},
+		{"invalid/name", true},
+		{"this-name-is-way-too-long-for-the-validation-to-pass-successfully", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateTemplateName(tt.name); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTemplateName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Add template name validation to prevent configuration collisions

#### 🚨 Severity: MEDIUM

#### 💡 Vulnerability:
The application lacked validation for template names during creation and updates. This allowed users to create templates with reserved names like `config`, which conflicts with the global `[config]` section in `repositories.toml`, or names containing unsafe characters.

#### 🎯 Impact:
A template named `config` would be merged with or overwrite global configuration settings (like the default `author`). Additionally, such a template would be inaccessible as a command because the CLI framework would prioritize subcommands or internal help over the template-generated command.

#### 🔧 Fix:
1.  Implemented `parser.ValidateTemplateName(name string) error` in `internal/parser/main.go` with strict rules (alphanumeric/hyphen/underscore, max length 50, reserved word blacklist).
2.  Integrated this validation into `internal/cli/create.go` and `internal/cli/update.go`.
3.  Fixed a regex range bug identified during code review to ensure hyphens are treated as literals.

#### ✅ Verification:
- Added unit tests in `internal/parser/security_test.go` covering valid names, reserved names, invalid characters, and length limits.
- Manually verified that `glyph create --name config ...` and `glyph create --name "invalid name" ...` are now rejected with clear error messages.
- Ran all existing tests with `go test ./...` and they pass.

---
*PR created automatically by Jules for task [1685193526549262202](https://jules.google.com/task/1685193526549262202) started by @DanteDev2102*