### PR TITLE
🛡️ Sentinel: [MEDIUM] Add template name validation

### DIFF
--- a/internal/parser/validation.go
+++ b/internal/parser/validation.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+var reservedWords = map[string]bool{
+	"config":     true,
+	"help":       true,
+	"init":       true,
+	"create":     true,
+	"rm":         true,
+	"set":        true,
+	"list":       true,
+	"glyph":      true,
+	"completion": true,
+}
+
+// ValidateTemplateName ensures that the template name is valid and not a reserved word.
+func ValidateTemplateName(name string) error {
+	if len(name) == 0 {
+		return errors.New("template name cannot be empty")
+	}
+	if len(name) > 50 {
+		return fmt.Errorf("template name %q is too long (max 50 characters)", name)
+	}
+	if !nameRegex.MatchString(name) {
+		return fmt.Errorf("template name %q contains invalid characters (only alphanumeric, hyphens, and underscores allowed)", name)
+	}
+	if reservedWords[name] {
+		return fmt.Errorf("template name %q is a reserved word", name)
+	}
+	return nil
+}

--- a/internal/parser/validation_test.go
+++ b/internal/parser/validation_test.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTemplateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"valid-name", false},
+		{"valid_name_123", false},
+		{"a", false},
+		{"", true},                                     // Empty name
+		{strings.Repeat("a", 51), true},               // Too long
+		{"invalid name", true},                         // Space
+		{"invalid@name", true},                         // Special char
+		{"config", true},                               // Reserved word
+		{"help", true},                                 // Reserved word
+		{"init", true},                                 // Reserved word
+		{"create", true},                               // Reserved word
+		{"rm", true},                                   // Reserved word
+		{"set", true},                                  // Reserved word
+		{"list", true},                                 // Reserved word
+		{"glyph", true},                                // Reserved word
+		{"completion", true},                           // Reserved word
+		{"valid-Name-123_456", false},                  // Mixed
+	}
+
+	for _, tt := range tests {
+		err := ValidateTemplateName(tt.name)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateTemplateName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -22,6 +22,11 @@ type Template struct {
 }
 
 func (p *Parser) Write(tmpl *Template) {
+	if err := ValidateTemplateName(tmpl.Name); err != nil {
+		fmt.Printf("Validation error: %v\n", err)
+		return
+	}
+
 	var config map[string]interface{}
 	if err := toml.Unmarshal(p.Content, &config); err != nil || config == nil {
 		config = make(map[string]interface{})
@@ -88,6 +93,13 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	if tmpl.Branch != "" && tmpl.Tag != "" {
 		fmt.Println("Only branch or tag flag")
 		return
+	}
+
+	if tmpl.Name != "" {
+		if err := ValidateTemplateName(tmpl.Name); err != nil {
+			fmt.Printf("Validation error: %v\n", err)
+			return
+		}
 	}
 
 	var newValues = make(map[string]string)


### PR DESCRIPTION
Implemented template name validation to improve security and robustness. The enhancement prevents users from creating templates with reserved names (like 'config', 'help', 'init') which could overwrite critical configuration sections or conflict with CLI subcommands. It also enforces a length limit and a safe character set (alphanumeric, hyphens, and underscores) to avoid potential injection or filesystem issues.

Summary of changes:
- Created `internal/parser/validation.go` with `ValidateTemplateName`.
- Updated `internal/parser/write.go` to call validation before persisting templates.
- Added unit tests in `internal/parser/validation_test.go`.
- Verified with full test suite.

---
*PR created automatically by Jules for task [1227298131655878849](https://jules.google.com/task/1227298131655878849) started by @DanteDev2102*