### PR TITLE
🛡️ Sentinel: [MEDIUM] Add template name validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Configuration file created with world-readable permissions (0644).
 **Learning:** Default file creation permissions in many languages/environments are overly permissive for configuration files that may contain sensitive user information or preferences.
 **Prevention:** Explicitly set restricted permissions (e.g., 0600) when creating or writing to configuration files to ensure only the owner can access them.
+
+## 2026-05-10 - Template Name Validation and Reserved Words
+**Vulnerability:** Collision with CLI commands and potential injection via unrestricted template names. Users could create templates named after internal commands (e.g., "config", "help") or use special characters that might be misinterpreted by the shell or configuration parser.
+**Learning:** User-provided keys for configuration sections must be strictly validated to prevent collisions with reserved words and to ensure they only contain safe characters.
+**Prevention:** Implement a whitelist-based validation for all user-defined identifiers. Enforce length limits and check against a list of reserved words before persisting them to the configuration.

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -19,7 +19,14 @@ func (cli *Base) CreateCmd() {
 			if name == "" || (repo == "" && localPath == "") {
 				fmt.Println("name and (repo or local) flags required")
 				return
-			} else if branch != "" && tag != "" {
+			}
+
+			if err := parser.ValidateTemplateName(name); err != nil {
+				fmt.Printf("Invalid template name: %v\n", err)
+				return
+			}
+
+			if branch != "" && tag != "" {
 				fmt.Println("Use only branch or only tag for create new project template")
 				return
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/DanteDev2102/Glyph/config"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
@@ -14,6 +16,13 @@ func (cli *Base) UpdateCmd() {
 		Long:  config.SetDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if name != "" {
+				if err := parser.ValidateTemplateName(name); err != nil {
+					fmt.Printf("Invalid new template name: %v\n", err)
+					return
+				}
+			}
+
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,
 				Repo:        repo,

--- a/internal/parser/validation.go
+++ b/internal/parser/validation.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var reservedWords = map[string]bool{
+	"config":     true,
+	"help":       true,
+	"init":       true,
+	"create":     true,
+	"rm":         true,
+	"set":        true,
+	"list":       true,
+	"glyph":      true,
+	"completion": true,
+}
+
+var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ValidateTemplateName checks if the template name is valid.
+func ValidateTemplateName(name string) error {
+	if len(name) == 0 {
+		return errors.New("template name cannot be empty")
+	}
+
+	if len(name) > 50 {
+		return fmt.Errorf("template name too long (max 50 characters): %d", len(name))
+	}
+
+	if !nameRegex.MatchString(name) {
+		return errors.New("template name contains invalid characters (only alphanumeric, hyphens, and underscores allowed)")
+	}
+
+	if reservedWords[strings.ToLower(name)] {
+		return fmt.Errorf("template name '%s' is a reserved word and cannot be used", name)
+	}
+
+	return nil
+}

--- a/internal/parser/validation_test.go
+++ b/internal/parser/validation_test.go
@@ -1,0 +1,37 @@
+package parser
+
+import "testing"
+
+func TestValidateTemplateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"valid-name", false},
+		{"ValidName123", false},
+		{"valid_name", false},
+		{"", true},
+		{"this-name-is-exactly-fifty-characters-long-123456", false},
+		{"this-name-is-too-long-because-it-has-more-than-fifty-chars", true},
+		{"invalid name", true},
+		{"invalid@name", true},
+		{"config", true},
+		{"HELP", true},
+		{"init", true},
+		{"create", true},
+		{"rm", true},
+		{"set", true},
+		{"list", true},
+		{"glyph", true},
+		{"completion", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTemplateName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTemplateName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Lack of input validation for template names allowed for collisions with CLI commands and potential injection.
🎯 Impact: Users could create templates with names that shadow internal commands (e.g., "config", "help") or contain characters that could cause issues in configuration parsing or shell usage.
🔧 Fix: Implemented `ValidateTemplateName` in `internal/parser/validation.go` which enforces:
- Max 50 characters length limit.
- Whitelist of characters: alphanumeric, hyphens, and underscores.
- Prevention of reserved words (config, help, init, create, rm, set, list, glyph, completion).
✅ Verification:
- Unit tests in `internal/parser/validation_test.go` cover various valid/invalid cases.
- Integrated validation into `create` and `update` CLI commands.
- Verified all tests pass with `go test ./...`.

---
*PR created automatically by Jules for task [5424734620356608939](https://jules.google.com/task/5424734620356608939) started by @DanteDev2102*