### PR TITLE
🛡️ Sentinel: [MEDIUM] Implement template name validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Configuration file created with world-readable permissions (0644).
 **Learning:** Default file creation permissions in many languages/environments are overly permissive for configuration files that may contain sensitive user information or preferences.
 **Prevention:** Explicitly set restricted permissions (e.g., 0600) when creating or writing to configuration files to ensure only the owner can access them.
+
+## 2026-05-15 - Template Name Validation
+**Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
+**Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
+**Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.

--- a/internal/parser/validation.go
+++ b/internal/parser/validation.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var reservedWords = map[string]bool{
+	"config":     true,
+	"help":       true,
+	"init":       true,
+	"create":     true,
+	"rm":         true,
+	"set":        true,
+	"list":       true,
+	"glyph":      true,
+	"completion": true,
+}
+
+var validNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ValidateTemplateName ensures the template name is safe and valid.
+func ValidateTemplateName(name string) error {
+	if len(name) == 0 {
+		return errors.New("template name cannot be empty")
+	}
+
+	if len(name) > 50 {
+		return fmt.Errorf("template name is too long (max 50 characters): %d", len(name))
+	}
+
+	if !validNameRegex.MatchString(name) {
+		return fmt.Errorf("template name contains invalid characters: %s (only alphanumeric, hyphens, and underscores allowed)", name)
+	}
+
+	if reservedWords[strings.ToLower(name)] {
+		return fmt.Errorf("template name '%s' is a reserved word", name)
+	}
+
+	return nil
+}

--- a/internal/parser/validation_test.go
+++ b/internal/parser/validation_test.go
@@ -1,0 +1,41 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTemplateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"valid-name", false},
+		{"valid_name_123", false},
+		{"A", false},
+		{"", true},
+		{strings.Repeat("a", 51), true},
+		{"invalid name", true},
+		{"invalid@name", true},
+		{"invalid.name", true},
+		{"config", true},
+		{"CONFIG", true},
+		{"help", true},
+		{"init", true},
+		{"create", true},
+		{"rm", true},
+		{"set", true},
+		{"list", true},
+		{"glyph", true},
+		{"completion", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTemplateName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTemplateName(%s) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -22,6 +22,11 @@ type Template struct {
 }
 
 func (p *Parser) Write(tmpl *Template) {
+	if err := ValidateTemplateName(tmpl.Name); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
 	var config map[string]interface{}
 	if err := toml.Unmarshal(p.Content, &config); err != nil || config == nil {
 		config = make(map[string]interface{})
@@ -71,6 +76,13 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	if tmpl.Name != "" {
+		if err := ValidateTemplateName(tmpl.Name); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+	}
+
 	var config map[string]map[string]string
 
 	err := toml.Unmarshal(p.Content, &config)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Lack of input validation for template names in `glyph create` and `glyph set`.
🎯 Impact: An attacker or user could accidentally/intentionally overwrite the global `[config]` section or create templates that collide with CLI commands like `help`, `init`, etc.
🔧 Fix: Implemented `ValidateTemplateName` in `internal/parser/validation.go` and integrated it into the `Parser.Write` and `Parser.WriteSection` methods.
✅ Verification: Added comprehensive unit tests in `internal/parser/validation_test.go` covering valid names, length limits, invalid characters, and reserved words. Ran all project tests.

---
*PR created automatically by Jules for task [14000644467093993017](https://jules.google.com/task/14000644467093993017) started by @DanteDev2102*