### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during project initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-20 - File Permission Preservation during Initialization
+**Vulnerability:** Loss of restrictive file permissions during project initialization. A template might contain files with restricted permissions (e.g., 0600 for private keys or secrets), but copying them without explicitly preserving modes could result in world-readable files (0644) in the target project.
+**Learning:** Standard file creation in Go (`os.Create`) defaults to 0666 (modified by umask), which often results in 0644. When bootstrapping projects from templates, it is critical to propagate the security intent of the original files by preserving their permissions.
+**Prevention:** Use `os.Lstat` to retrieve the source file's mode and `os.OpenFile` with `info.Mode().Perm()` to ensure the destination file has the same level of protection as the source.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,10 +220,12 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source %s is a symbolic link", src)
-		}
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symbolic link", src)
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
@@ -239,7 +241,7 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As 'Sentinel', I have identified a security risk where project templates with restricted file permissions (like 0600 for sensitive configuration or private keys) would lose those restrictions when initialized by Glyph, defaulting to world-readable (0644).

I have addressed this by:
1. Modifying `internal/cli/init.go`'s `copyDir`, `copyFile`, and `replaceInFile` functions to capture the source/original file's permission mode and applying it to the new or modified files using `Mode().Perm()`.
2. Ensuring that errors from `os.Lstat` are correctly handled to avoid potential nil-pointer dereferences.
3. Adding a new test file `internal/cli/permission_test.go` that verifies that restricted permissions (0600) are correctly maintained after copying and after variable replacement (like in README.md).

These changes ensure the Principle of Least Privilege is maintained during the project bootstrapping process.

---
*PR created automatically by Jules for task [1373077519516057092](https://jules.google.com/task/1373077519516057092) started by @DanteDev2102*