### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during initialization

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,10 +220,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	srcInfo, err := os.Lstat(src)
+	if err == nil {
+		if srcInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("source %s is a symbolic link", src)
 		}
+	} else {
+		return err
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
@@ -239,7 +242,7 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restrictedFile := filepath.Join(srcDir, "restricted")
+	expectedPerm := os.FileMode(0600)
+	err = os.WriteFile(restrictedFile, []byte("restricted content"), expectedPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copiedFile := filepath.Join(dstDir, "restricted")
+	info, err := os.Stat(copiedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != expectedPerm {
+		t.Errorf("Expected permission %v, got %v", expectedPerm, info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	expectedPerm := os.FileMode(0600)
+	err = os.WriteFile(srcFile, []byte("restricted content"), expectedPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != expectedPerm {
+		t.Errorf("Expected permission %v, got %v", expectedPerm, info.Mode().Perm())
+	}
+}
+
+func TestReplaceInFile_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "test")
+	expectedPerm := os.FileMode(0600)
+	err = os.WriteFile(testFile, []byte("Hello {{.Name}}"), expectedPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "World"}
+	replaceInFile(testFile, replacements)
+
+	info, err := os.Stat(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != expectedPerm {
+		t.Errorf("Expected permission %v, got %v", expectedPerm, info.Mode().Perm())
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "Hello World" {
+		t.Errorf("Expected content 'Hello World', got '%s'", string(content))
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure / Insecure File Permissions. Files in templates or licenses could have restricted permissions (e.g., 0600) that were lost during project initialization, defaulting to overly permissive modes (e.g., 0644).
🎯 Impact: Sensitive files in a project template might become readable by other users on the same system.
🔧 Fix: Updated `copyDir`, `copyFile`, and `replaceInFile` to retrieve the original file's permissions using `os.Lstat` and apply them to the destination file using `os.OpenFile` or `os.WriteFile`.
✅ Verification: Added `internal/cli/permission_test.go` which verifies that restricted permissions are preserved across all identified operations.

---
*PR created automatically by Jules for task [6541116043028554162](https://jules.google.com/task/6541116043028554162) started by @DanteDev2102*