### PR TITLE
🛡️ Sentinel: [security improvement] Preserve file permissions during copy

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,8 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		// Explicitly use source file permissions when creating the destination file
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -239,7 +240,14 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	// Get source file information to preserve permissions
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	// Explicitly use source file permissions when creating the destination file
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissionPreservation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-perm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	dstDir := filepath.Join(tmpDir, "dst")
+
+	// Create source directory with specific permissions
+	err = os.MkdirAll(srcDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file with specific permissions
+	srcFile := filepath.Join(srcDir, "testfile")
+	err = os.WriteFile(srcFile, []byte("test content"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test copyFile
+	dstFile := filepath.Join(tmpDir, "dstfile")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatalf("copyFile failed: %v", err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("copyFile: expected permissions 0600, got %o", info.Mode().Perm())
+	}
+
+	// Test copyDir
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatalf("copyDir failed: %v", err)
+	}
+
+	// Check dstDir permissions
+	info, err = os.Stat(dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyDir (directory): expected permissions 0700, got %o", info.Mode().Perm())
+	}
+
+	// Check dstDir/testfile permissions
+	info, err = os.Stat(filepath.Join(dstDir, "testfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("copyDir (file): expected permissions 0600, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🚨 Severity: LOW (Security Enhancement)
💡 Vulnerability: When initializing a project from a local template or injecting a license, the tool was not explicitly preserving the source file permissions. This could lead to sensitive files (like templates with restricted access) becoming more permissive than intended in the destination project.
🎯 Impact: Potential information exposure if sensitive template files lose their restricted permissions during copy.
🔧 Fix: Modified `copyDir` and `copyFile` in `internal/cli/init.go` to use `os.OpenFile` with the source file's permission bits (`info.Mode().Perm()`) instead of the default permissions provided by `os.Create`.
✅ Verification: Added `internal/cli/permission_test.go` which verifies that both files and directories maintain their source permissions after being copied. All project tests passed.

---
*PR created automatically by Jules for task [11724703853326702775](https://jules.google.com/task/11724703853326702775) started by @DanteDev2102*