### PR TITLE
🛡️ Sentinel: [Enhancement] Preserve file permissions during template initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-10 - Permission Loss during Template Copying
+**Vulnerability:** Loss of executable bits and restricted permissions when initializing projects from templates.
+**Learning:** Using `os.Create` or `os.WriteFile` with default permissions for scaffolding can strip necessary metadata (like executable bits for scripts) or inadvertently loosen restricted permissions.
+**Prevention:** Always use `os.Lstat` to retrieve source file permissions and use `os.OpenFile` with explicit mode bits to preserve the security posture of the original template files. On Unix, `os.WriteFile` preserves existing permissions when overwriting, so explicit preservation is only mandatory for new files.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -220,10 +220,12 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source %s is a symbolic link", src)
-		}
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symbolic link", src)
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
@@ -239,7 +241,7 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissionPreservation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-perm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// 1. Test copyFile permission preservation
+	srcFile := filepath.Join(tmpDir, "src_script.sh")
+	// Create an executable file with restricted permissions
+	err = os.WriteFile(srcFile, []byte("#!/bin/sh\necho hello"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst_script.sh")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyFile: Expected permissions 0700, got %o", info.Mode().Perm())
+	}
+
+	// 2. Test replaceInFile permission preservation (behavioral check)
+	readmeFile := filepath.Join(tmpDir, "README.md")
+	err = os.WriteFile(readmeFile, []byte("Hello {{.Name}}"), 0400) // Read-only for owner
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replaceInFile(readmeFile, map[string]string{"Name": "Sentinel"})
+
+	info, err = os.Stat(readmeFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// On Unix, writing to an existing file should NOT change its permissions even if a different mode is passed to WriteFile.
+	if info.Mode().Perm() != 0400 {
+		t.Errorf("replaceInFile: Expected permissions 0400 to be preserved, got %o", info.Mode().Perm())
+	}
+
+	// 3. Test copyDir permission preservation
+	srcDir := filepath.Join(tmpDir, "src_dir")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nestedFile := filepath.Join(srcDir, "nested.sh")
+	err = os.WriteFile(nestedFile, []byte("echo nested"), 0711)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst_dir")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err = os.Stat(filepath.Join(dstDir, "nested.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0711 {
+		t.Errorf("copyDir: Expected permissions 0711 for nested file, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: Loss of file permissions (executable bits, restricted access) during project initialization from templates.
🎯 Impact: Scripts in the initialized project might lose their executable status, and files with restricted permissions might become world-readable depending on the system umask.
🔧 Fix: Modified `copyFile` and `copyDir` in `internal/cli/init.go` to use `os.OpenFile` with the original source file's permissions instead of `os.Create`.
✅ Verification: Created a new test `internal/cli/permission_test.go` which verifies permission preservation for files, nested directories, and behavioral consistency for variable replacement. Ran `go test ./...` and confirmed all tests pass.

---
*PR created automatically by Jules for task [1540364340110649194](https://jules.google.com/task/1540364340110649194) started by @DanteDev2102*