### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during template initialization

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,13 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	// Get source file info to preserve permissions
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpSrc, err := os.MkdirTemp("", "glyph-test-src-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpSrc)
+
+	tmpDst, err := os.MkdirTemp("", "glyph-test-dst-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDst)
+
+	// Test restricted file (0600)
+	restrictedFile := filepath.Join(tmpSrc, "restricted")
+	if err := os.WriteFile(restrictedFile, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test executable file (0700)
+	executableFile := filepath.Join(tmpSrc, "executable")
+	if err := os.WriteFile(executableFile, []byte("#!/bin/sh"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(tmpSrc, tmpDst); err != nil {
+		t.Fatalf("copyDir failed: %v", err)
+	}
+
+	// Check restricted file permissions
+	info, err := os.Stat(filepath.Join(tmpDst, "restricted"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected permission 0600, got %o", info.Mode().Perm())
+	}
+
+	// Check executable file permissions
+	info, err = os.Stat(filepath.Join(tmpDst, "executable"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("Expected permission 0700, got %o", info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	src := filepath.Join(tmpDir, "src")
+	dst := filepath.Join(tmpDir, "dst")
+
+	if err := os.WriteFile(src, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile failed: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected permission 0600, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Insecure File Permissions
The `copyDir` and `copyFile` functions used `os.Create` when copying template files, which uses `0666` (masked by umask) as the default mode. This could lead to sensitive files in a template (like private keys or local configs) being created with overly permissive world-readable permissions. Additionally, executable bits on scripts were lost during the copy process.

### 🎯 Impact: 
1. **Information Disclosure:** Sensitive template files could be read by other users on a multi-user system.
2. **Broken Functionality:** Executable scripts in templates lose their execution bit, requiring manual `chmod` by the user after initialization.

### 🔧 Fix:
Updated `copyDir` and `copyFile` to use `os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, sourcePerm)` where `sourcePerm` is retrieved from the original source file using `os.Lstat`. This ensures the principle of least privilege is maintained by duplicating the source's access controls.

### ✅ Verification:
1. Created `internal/cli/permission_test.go` which sets up a source directory with files having `0600` and `0700` modes.
2. Verified that without the fix, the copied files had `0664` permissions.
3. Verified that after the fix, the copied files correctly retained `0600` and `0700` modes.
4. Ran `go test ./...` to ensure no regressions in other security or core features.

---
*PR created automatically by Jules for task [5924392152640563161](https://jules.google.com/task/5924392152640563161) started by @DanteDev2102*