### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during initialization

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,14 +50,17 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
 		defer dstFile.Close()
 
-		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if _, err = io.Copy(dstFile, srcFile); err != nil {
+			return err
+		}
+
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -99,7 +102,10 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	if err := os.WriteFile(filePath, []byte(s), info.Mode().Perm()); err != nil {
+		return
+	}
+	os.Chmod(filePath, info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,15 +226,18 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
+	info, err := os.Lstat(src)
+	if err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("source %s is a symbolic link", src)
 		}
+	} else {
+		return err
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
-	if info, err := os.Lstat(dst); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	if dstInfo, err := os.Lstat(dst); err == nil {
+		if dstInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("destination %s is a symbolic link", dst)
 		}
 	}
@@ -239,14 +248,17 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, in)
-	return err
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, info.Mode().Perm())
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-perm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an executable file
+	execFile := filepath.Join(srcDir, "exec_file")
+	err = os.WriteFile(execFile, []byte("#!/bin/sh\necho hi"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a read-only file
+	readOnlyFile := filepath.Join(srcDir, "readonly_file")
+	err = os.WriteFile(readOnlyFile, []byte("read only"), 0444)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check permissions of executable file
+	info, err := os.Stat(filepath.Join(dstDir, "exec_file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("Expected 0755 perm for exec_file, got %o", info.Mode().Perm())
+	}
+
+	// Check permissions of read-only file
+	info, err = os.Stat(filepath.Join(dstDir, "readonly_file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0444 {
+		t.Errorf("Expected 0444 perm for readonly_file, got %o", info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-fileperm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src_exec")
+	err = os.WriteFile(srcFile, []byte("exec content"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst_exec")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("Expected 0700 perm for dst_exec, got %o", info.Mode().Perm())
+	}
+}
+
+func TestReplaceInFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-replaceperm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	targetFile := filepath.Join(tmpDir, "perm_check")
+	err = os.WriteFile(targetFile, []byte("Hello {{.Name}}"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "Sentinel"}
+	replaceInFile(targetFile, replacements)
+
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "Hello Sentinel" {
+		t.Errorf("Content mismatch: %s", string(content))
+	}
+
+	info, err := os.Stat(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected 0600 perm for perm_check, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Files initialized from templates would lose their original permissions, such as executable bits on scripts, or restrictive permissions (e.g., 0600) would be reset to the default 0644. This could lead to malfunctioning projects or unintended permission relaxation.
🎯 Impact: Template scripts require manual `chmod +x` after initialization, and sensitive files could have their access widened unexpectedly.
🔧 Fix: Updated the initialization logic to use `os.Lstat` for permission retrieval and `os.Chmod` for explicit application after file write operations.
✅ Verification: Added a new test suite in `internal/cli/permission_test.go` covering directory copy, single file copy, and in-place replacement. All tests passed.

---
*PR created automatically by Jules for task [14085734418744980014](https://jules.google.com/task/14085734418744980014) started by @DanteDev2102*