### PR TITLE
🛡️ Sentinel: preserve file permissions in template operations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-03-12 - File Permission Preservation in Template Operations
+**Vulnerability:** Loss of original file permissions (e.g., executable bits, restricted read/write) during template copy operations.
+**Learning:** Standard file copy operations using `os.Create` and `io.Copy` do not automatically replicate source file permissions, which can lead to broken scripts or insecurely exposed files in the initialized project.
+**Prevention:** Explicitly retrieve the source file's mode using `os.Lstat` and apply it to the destination file using `os.Chmod` after the copy operation is complete.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -57,7 +57,11 @@ func copyDir(src string, dst string) error {
 		defer dstFile.Close()
 
 		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if err != nil {
+			return err
+		}
+
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -220,8 +224,9 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	srcInfo, err := os.Lstat(src)
+	if err == nil {
+		if srcInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("source %s is a symbolic link", src)
 		}
 	}
@@ -246,7 +251,15 @@ func copyFile(src, dst string) error {
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if srcInfo != nil {
+		return os.Chmod(dst, srcInfo.Mode().Perm())
+	}
+
+	return nil
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/permission_test.go
+++ b/internal/cli/permission_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissionPreservation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	err = os.WriteFile(srcFile, []byte("test"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyFile: Expected permission 0700, got %o", info.Mode().Perm())
+	}
+
+	// Test copyDir
+	srcDir := filepath.Join(tmpDir, "srcdir")
+	err = os.Mkdir(srcDir, 0750)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFileInDir := filepath.Join(srcDir, "file")
+	err = os.WriteFile(srcFileInDir, []byte("test"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dstdir")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err = os.Stat(dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0750 {
+		t.Errorf("copyDir: Expected dir permission 0750, got %o", info.Mode().Perm())
+	}
+
+	info, err = os.Stat(filepath.Join(dstDir, "file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyDir: Expected file permission 0700, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM (Security Enhancement)
💡 Vulnerability: Template file permissions (like executable bits or restricted access) were lost during the initialization process because standard copy operations don't preserve file modes.
🎯 Impact: Scripts in templates would lose their executable status, requiring manual fixing by the user. Additionally, files intended to have restricted permissions might be created with default system permissions (0644/0755), potentially exposing sensitive template content.
🔧 Fix: Updated `copyFile` and `copyDir` in `internal/cli/init.go` to capture the source file's mode using `os.Lstat` and explicitly apply it to the destination file using `os.Chmod` after the copy.
✅ Verification: Created a new test `internal/cli/permission_test.go` that verifies both individual file and directory-wide permission preservation. Ran `go test ./...` and all tests passed.

---
*PR created automatically by Jules for task [6762304156645987293](https://jules.google.com/task/6762304156645987293) started by @DanteDev2102*