### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during template initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-18 - File Permission Preservation during Template Copy
+**Vulnerability:** Loss of file permissions (e.g., executable bits) during project initialization from templates.
+**Learning:** Default file creation (`os.Create`) does not preserve source permissions. This can lead to security risks if users apply overly permissive fixes (like `chmod 777`) to restored files.
+**Prevention:** Explicitly retrieve source file permissions using `os.Lstat` and apply them to the destination using `os.Chmod` after the file is created.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -57,7 +57,12 @@ func copyDir(src string, dst string) error {
 		defer dstFile.Close()
 
 		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// Security enhancement: Preserve file permissions
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -246,7 +251,16 @@ func copyFile(src, dst string) error {
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Security enhancement: Preserve file permissions
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcInfo.Mode().Perm())
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/reproduce_permission_issue_test.go
+++ b/internal/cli/reproduce_permission_issue_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-perm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exeFile := filepath.Join(srcDir, "script.sh")
+	err = os.WriteFile(exeFile, []byte("#!/bin/sh\necho hello"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copiedFile := filepath.Join(dstDir, "script.sh")
+	info, err := os.Stat(copiedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0755)
+	if info.Mode().Perm() != expectedPerm {
+		t.Errorf("Expected permissions %v, got %v", expectedPerm, info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-file-perm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "script.sh")
+	err = os.WriteFile(srcFile, []byte("#!/bin/sh\necho hello"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "script_copy.sh")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0755)
+	if info.Mode().Perm() != expectedPerm {
+		t.Errorf("Expected permissions %v, got %v", expectedPerm, info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Preserve file permissions during template initialization

When initializing a project from a template, file permissions (such as the executable bit) were being lost because `os.Create` uses default permissions. This fix ensures that source file permissions are explicitly preserved using `os.Chmod` in `copyDir` and `copyFile`.

- Modified `internal/cli/init.go` to preserve permissions.
- Added a reproduction test `internal/cli/reproduce_permission_issue_test.go`.
- Updated `.jules/sentinel.md` with the new learning.

---
*PR created automatically by Jules for task [14075832509818459478](https://jules.google.com/task/14075832509818459478) started by @DanteDev2102*