### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions during initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-18 - Preservation of File Permissions during Template Initialization
+**Vulnerability:** Insecure file permissions during project scaffolding. When cloning or copying templates, file permissions (including the executable bit and restricted access modes like 0600) were lost, defaulting to system-wide permissive modes (e.g., 0644).
+**Learning:** Default file creation and copying operations in many standard libraries do not automatically replicate source permissions, which can expose sensitive configuration files or break scripts in the generated project.
+**Prevention:** Always retrieve the source file's `os.FileMode` using `os.Lstat` and explicitly apply it to the destination using `os.Chmod` or by passing `info.Mode().Perm()` to file creation functions like `os.OpenFile`.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -41,7 +41,7 @@ func copyDir(src string, dst string) error {
 		}
 
 		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode())
+			return os.MkdirAll(target, info.Mode().Perm())
 		}
 
 		srcFile, err := os.Open(path)
@@ -50,14 +50,18 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
 		defer dstFile.Close()
 
 		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if err != nil {
+			return err
+		}
+
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -99,7 +103,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,10 +224,12 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source %s is a symbolic link", src)
-		}
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symbolic link", src)
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
@@ -239,14 +245,18 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	return err
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, info.Mode().Perm())
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/reproduce_permission_issue_test.go
+++ b/internal/cli/reproduce_permission_issue_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissionsPreservation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-perm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	dstDir := filepath.Join(tmpDir, "dst")
+
+	// 1. Test copyDir permissions preservation
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restrictedFile := filepath.Join(srcDir, "restricted.sh")
+	err = os.WriteFile(restrictedFile, []byte("#!/bin/sh\necho hi"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dstDir, "restricted.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyDir did not preserve permissions: expected 0700, got %o", info.Mode().Perm())
+	}
+
+	// 2. Test copyFile permissions preservation
+	srcLicense := filepath.Join(tmpDir, "LICENSE.test")
+	dstLicense := filepath.Join(tmpDir, "LICENSE.dst")
+	err = os.WriteFile(srcLicense, []byte("license content"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = copyFile(srcLicense, dstLicense)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err = os.Stat(dstLicense)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("copyFile did not preserve permissions: expected 0600, got %o", info.Mode().Perm())
+	}
+
+	// 3. Test replaceInFile permissions preservation
+	readmePath := filepath.Join(tmpDir, "README.md")
+	err = os.WriteFile(readmePath, []byte("Hello {{.Author}}"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Author": "Sentinel"}
+	replaceInFile(readmePath, replacements)
+
+	info, err = os.Stat(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("replaceInFile did not preserve permissions: expected 0600, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions during initialization

### 🚨 Severity
MEDIUM

### 💡 Vulnerability
Insecure file permissions during project scaffolding. When cloning or copying templates, file permissions (including the executable bit and restricted access modes like 0600) were lost, defaulting to system-wide permissive modes (e.g., 0644).

### 🎯 Impact
Sensitive files in templates (like .env files or private keys) could become world-readable, and scripts could lose their executable bit, leading to security risks or broken functionality in the generated project.

### 🔧 Fix
Updated `copyDir`, `copyFile`, and `replaceInFile` in `internal/cli/init.go` to retrieve source file permissions using `os.Lstat` and explicitly apply them to the destination using `os.OpenFile` and `os.Chmod`.

### ✅ Verification
Added a reproduction test in `internal/cli/reproduce_permission_issue_test.go` that verifies 0700 and 0600 permissions are preserved across all modified functions. All existing tests also pass.

---
*PR created automatically by Jules for task [10441829384082774021](https://jules.google.com/task/10441829384082774021) started by @DanteDev2102*