### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve and enforce secure file permissions

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -57,7 +57,12 @@ func copyDir(src string, dst string) error {
 		defer dstFile.Close()
 
 		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// Security check: Preserve original file permissions
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -99,7 +104,8 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	// Security check: Preserve original file permissions
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,15 +226,17 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source %s is a symbolic link", src)
-		}
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symbolic link", src)
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
-	if info, err := os.Lstat(dst); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	if dstInfo, err := os.Lstat(dst); err == nil {
+		if dstInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("destination %s is a symbolic link", dst)
 		}
 	}
@@ -246,7 +254,12 @@ func copyFile(src, dst string) error {
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Security check: Preserve original file permissions
+	return os.Chmod(dst, info.Mode().Perm())
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/reproduce_permission_issue_test.go
+++ b/internal/cli/reproduce_permission_issue_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executableFile := filepath.Join(srcDir, "run.sh")
+	err = os.WriteFile(executableFile, []byte("#!/bin/sh\necho hi"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dstDir, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("copyDir failed to preserve permissions: expected %o, got %o", 0700, info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	err = os.WriteFile(srcFile, []byte("content"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("copyFile failed to preserve permissions: expected %o, got %o", 0600, info.Mode().Perm())
+	}
+}
+
+func TestReplaceInFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	file := filepath.Join(tmpDir, "README.md")
+	err = os.WriteFile(file, []byte("Project: {{.ProjectName}}"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"ProjectName": "Test"}
+	replaceInFile(file, replacements)
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("replaceInFile failed to preserve permissions: expected %o, got %o", 0600, info.Mode().Perm())
+	}
+}

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,9 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	if err := os.WriteFile(p.File, data, 0600); err != nil {
+		return err
+	}
+
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/reproduce_permission_issue_test.go
+++ b/internal/parser/reproduce_permission_issue_test.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeWrite_EnforcePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confFile := filepath.Join(tmpDir, "repositories.toml")
+	// Pre-create with insecure permissions
+	err = os.WriteFile(confFile, []byte(""), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{File: confFile}
+	err = p.safeWrite([]byte("test = 1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(confFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("safeWrite failed to enforce 0600: expected %o, got %o", 0600, info.Mode().Perm())
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,7 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -153,7 +153,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
This PR addresses several security concerns related to file permissions and symlink protection:

1. **Permission Preservation**: Templates may contain executable scripts or files with specific permissions. Previously, these were lost during the initialization process. `copyDir`, `copyFile`, and `replaceInFile` now explicitly preserve and apply the original file permissions using `os.Chmod`.
2. **Configuration Hardening**: The global configuration file `repositories.toml` could potentially have insecure permissions if pre-created by a user or another process. `safeWrite` now explicitly calls `os.Chmod(p.File, 0600)` after every write to ensure strict access control.
3. **Secure Defaults**: The configuration directory is now created with `0700` (user-only) permissions instead of `0755` (world-readable), following the principle of least privilege for sensitive application data.
4. **Symlink Protection Refactoring**: `copyFile` has been refactored to use `os.Lstat` more robustly, ensuring that symlink attacks are blocked at both source and destination consistently.

Verification:
- New tests in `internal/cli/reproduce_permission_issue_test.go` and `internal/parser/reproduce_permission_issue_test.go` verify that permissions are correctly preserved and enforced.
- All existing security tests pass.
- Manual verification of build success.

---
*PR created automatically by Jules for task [9650604560645493644](https://jules.google.com/task/9650604560645493644) started by @DanteDev2102*