### PR TITLE
🛡️ Sentinel: Harden permissions and input validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-20 - Permission Preservation and Configuration Directory Hardening
+**Vulnerability:** Overly permissive configuration directory (0755) and loss of file permissions (e.g., executable bit) during template initialization and replacement.
+**Learning:** `os.WriteFile` and `os.Create` do not modify existing file permissions, and directory creation defaults are often too permissive. Security-sensitive tools must explicitly manage permissions using `os.Chmod`.
+**Prevention:** Use `0700` for configuration directories. Always capture source permissions using `os.Stat` or `os.Lstat` and explicitly apply them to destination or modified files using `os.Chmod`.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -41,7 +41,7 @@ func copyDir(src string, dst string) error {
 		}
 
 		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode())
+			return os.MkdirAll(target, info.Mode().Perm())
 		}
 
 		srcFile, err := os.Open(path)
@@ -57,7 +57,11 @@ func copyDir(src string, dst string) error {
 		defer dstFile.Close()
 
 		_, err = io.Copy(dstFile, srcFile)
-		return err
+		if err != nil {
+			return err
+		}
+
+		return os.Chmod(target, info.Mode().Perm())
 	})
 }
 
@@ -99,7 +103,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -246,7 +250,16 @@ func copyFile(src, dst string) error {
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	return err
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, info.Mode().Perm())
 }
 
 // InitCmd initializes the CLI with the "init" command.

--- a/internal/cli/reproduce_permission_issue_test.go
+++ b/internal/cli/reproduce_permission_issue_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceInFile_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "executable_script.sh")
+	content := []byte("#!/bin/bash\necho Hello {{.Name}}")
+	// Create with executable permissions
+	err = os.WriteFile(testFile, content, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "Sentinel"}
+	replaceInFile(testFile, replacements)
+
+	info, err := os.Stat(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0755).Perm()
+	actualPerm := info.Mode().Perm()
+
+	if actualPerm != expectedPerm {
+		t.Errorf("Permissions not preserved after replaceInFile. Expected %v, got %v", expectedPerm, actualPerm)
+	}
+}
+
+func TestCopyFile_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src_executable")
+	err = os.WriteFile(srcFile, []byte("content"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst_executable")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0700).Perm()
+	actualPerm := info.Mode().Perm()
+
+	if actualPerm != expectedPerm {
+		t.Errorf("Permissions not preserved after copyFile. Expected %v, got %v", expectedPerm, actualPerm)
+	}
+}
+
+func TestCopyDir_PreservesPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(srcDir, "exec")
+	err = os.WriteFile(srcFile, []byte("content"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(dstDir, "exec")
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0755).Perm()
+	actualPerm := info.Mode().Perm()
+
+	if actualPerm != expectedPerm {
+		t.Errorf("Permissions not preserved after copyDir. Expected %v, got %v", expectedPerm, actualPerm)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/DanteDev2102/Glyph/config"
+	"github.com/DanteDev2102/Glyph/internal/gitutils"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +17,14 @@ func (cli *Base) UpdateCmd() {
 		Long:  config.SetDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if repo != "" {
+				_, err := gitutils.ValidateRepo(repo)
+				if err != nil {
+					fmt.Printf("Error validating repository: %v\n", err)
+					return
+				}
+			}
+
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,
 				Repo:        repo,

--- a/internal/parser/reproduce_permission_issue_test.go
+++ b/internal/parser/reproduce_permission_issue_test.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMkdirAll_RestrictedPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, ".config", "Glyph")
+	p := &Parser{File: filepath.Join(confDir, "repositories.toml")}
+
+	tmpl := &Template{
+		Name: "test-tmpl",
+		Repo: "https://github.com/example/repo",
+	}
+
+	// This will trigger MkdirAll
+	p.Write(tmpl)
+
+	info, err := os.Stat(confDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPerm := os.FileMode(0700).Perm()
+	actualPerm := info.Mode().Perm()
+
+	if actualPerm != expectedPerm {
+		t.Errorf("Config directory created with overly permissive permissions. Expected %v, got %v", expectedPerm, actualPerm)
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,7 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -153,7 +153,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
This PR addresses multiple security gaps identified in the application:
1. **Permission Loss:** Previously, file initialization and variable replacement could lead to the loss of the executable bit on scripts. I've updated `replaceInFile`, `copyFile`, and `copyDir` to explicitly preserve source permissions using `os.Chmod`.
2. **Permissive Configuration:** The configuration directory was created with `0755` permissions. It is now restricted to `0700` to ensure only the owner can access it.
3. **Missing Input Validation:** The `set` command did not validate repository URLs. I've added a call to `gitutils.ValidateRepo` to ensure consistency with the `create` command and prevent malformed inputs.
4. **Verification:** New tests in `internal/cli/reproduce_permission_issue_test.go` and `internal/parser/reproduce_permission_issue_test.go` verify these fixes.


---
*PR created automatically by Jules for task [10549181126370313736](https://jules.google.com/task/10549181126370313736) started by @DanteDev2102*