### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden configuration parser security

### DIFF
--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -8,6 +8,11 @@ import (
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if name == "config" {
+		fmt.Println("Error: The 'config' section is reserved and cannot be deleted.")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,9 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	if err := os.WriteFile(p.File, data, 0600); err != nil {
+		return err
+	}
+
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,7 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -153,7 +153,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Configuration file and its parent directory were created with overly permissive permissions (e.g., world-readable). Additionally, the reserved `config` section was vulnerable to deletion.
🎯 Impact: Sensitive user configuration (like author name) could be exposed to other users on the system. Deletion of the `config` section could lead to application instability.
🔧 Fix:
- Explicitly enforce `0600` (read/write for owner only) permissions on the configuration file using `os.Chmod`.
- Restricted configuration directory creation to `0700` (owner only).
- Added a safeguard in `DeleteSection` to prevent the removal of the reserved `config` section.
✅ Verification: Successfully verified with unit tests and a reproduction test case that confirmed permission enforcement and section protection.

---
*PR created automatically by Jules for task [12219572115501531247](https://jules.google.com/task/12219572115501531247) started by @DanteDev2102*