### PR TITLE
🛡️ Sentinel: [MEDIUM] Protect reserved 'config' section from deletion

### DIFF
--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -8,6 +8,13 @@ import (
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	// Security check: 'config' is a reserved section for global settings.
+	// Protecting it from deletion ensures that critical configurations (like 'author') are preserved.
+	if name == "config" {
+		fmt.Println("Error: Cannot delete reserved 'config' section")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -48,3 +48,42 @@ func TestWrite_Symlink(t *testing.T) {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
 	}
 }
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Sentinel"
+
+[my-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Try to delete the 'config' section
+	p.DeleteSection("config")
+
+	// Read it back
+	config, err := p.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verification: The 'config' section SHOULD NOT be deleted
+	if _, ok := config["config"]; !ok {
+		t.Errorf("Expected 'config' section to be preserved, but it was deleted!")
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `rm` command could be used to delete the reserved `[config]` section from `repositories.toml`, which contains global settings like the default author.
🎯 Impact: Loss of global configuration settings, potentially leading to incorrect metadata in initialized projects or requiring manual restoration of the configuration file.
🔧 Fix: Added a security check in `internal/parser/delete.go` to explicitly reject deletion requests for the "config" section.
✅ Verification: Added a regression test `TestDeleteSection_ConfigProtection` in `internal/parser/security_test.go`.

---
*PR created automatically by Jules for task [14051255311303032104](https://jules.google.com/task/14051255311303032104) started by @DanteDev2102*