### PR TITLE
🛡️ Sentinel: [MEDIUM] Preserve file permissions during project initialization

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -239,7 +239,12 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/init_security_test.go
+++ b/internal/cli/init_security_test.go
@@ -88,3 +88,73 @@ func TestDstPathValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execFile := filepath.Join(srcDir, "exec.sh")
+	err = os.WriteFile(execFile, []byte("#!/bin/sh"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copiedFile := filepath.Join(dstDir, "exec.sh")
+	info, err := os.Stat(copiedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("Expected permissions 0755, got %o", info.Mode().Perm())
+	}
+}
+
+func TestReplaceInFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	execFile := filepath.Join(tmpDir, "exec.sh")
+	err = os.WriteFile(execFile, []byte("#!/bin/sh\necho {{.ProjectName}}"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"ProjectName": "TestApp"}
+	replaceInFile(execFile, replacements)
+
+	info, err := os.Stat(execFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("Expected permissions 0700, got %o", info.Mode().Perm())
+	}
+
+	content, err := os.ReadFile(execFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "TestApp") {
+		t.Errorf("Replacement failed, content: %s", string(content))
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Hardcoded file permissions (0644) during project initialization led to the loss of executable bits on scripts and potential permission escalation if the original file had more restrictive permissions.
🎯 Impact: Scripts (e.g., shell scripts, pre-commit hooks) lose their executable status after cloning a template, requiring manual user intervention. Additionally, files intended to be private (e.g., 0600) would be overwritten with 0644 permissions.
🔧 Fix: Modified `copyFile`, `copyDir`, and `replaceInFile` in `internal/cli/init.go` to obtain the source file's mode via `os.Lstat` and use those permissions when creating or writing to the destination file.
✅ Verification: Added new test cases `TestCopyDir_PreservePermissions` and `TestReplaceInFile_PreservePermissions` in `internal/cli/init_security_test.go`. Verified that `go build` and `go test` pass.

---
*PR created automatically by Jules for task [15151779543685303358](https://jules.google.com/task/15151779543685303358) started by @DanteDev2102*