### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix file permission regression in project initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-10 - Permission Regression in Project Initialization
+**Vulnerability:** File permissions (including executable bits) were lost during project initialization. `replaceInFile` hardcoded `0644`, and `copyFile`/`copyDir` used `os.Create` (defaulting to `0666` minus umask).
+**Learning:** Standard library functions like `os.Create` or `os.WriteFile` with hardcoded modes are unsuitable for tools that must mirror the state of a source repository or template.
+**Prevention:** Always use `os.Lstat` to capture the source file's `FileMode` and `os.OpenFile` with the captured mode to ensure consistent permission preservation across all file operations.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,8 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		// Preserve the source file permissions
+		dstFile, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -99,7 +100,8 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	// Preserve the original file permissions
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -220,10 +222,13 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 
 func copyFile(src, dst string) error {
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	srcInfo, err := os.Lstat(src)
+	if err == nil {
+		if srcInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("source %s is a symbolic link", src)
 		}
+	} else {
+		return err
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
@@ -239,7 +244,8 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	// Preserve the source file permissions
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/permission_security_test.go
+++ b/internal/cli/permission_security_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceInFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	file600 := filepath.Join(tmpDir, "file600")
+	err = os.WriteFile(file600, []byte("Hello {{.Name}}"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"Name": "World"}
+	replaceInFile(file600, replacements)
+
+	info, err := os.Stat(file600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected permissions 0600, got %v", info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "src")
+	err = os.WriteFile(srcFile, []byte("content"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstFile := filepath.Join(tmpDir, "dst")
+	err = copyFile(srcFile, dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected permissions 0600, got %v", info.Mode().Perm())
+	}
+}
+
+func TestCopyDir_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcDir := filepath.Join(tmpDir, "src")
+	err = os.Mkdir(srcDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcFile := filepath.Join(srcDir, "file")
+	err = os.WriteFile(srcFile, []byte("content"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(tmpDir, "dst")
+	err = copyDir(srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dstDir, "file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Expected permissions 0600, got %v", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: File permissions (including executable bits) were lost during project initialization. `replaceInFile` hardcoded `0644`, and `copyFile`/`copyDir` used `os.Create` (defaulting to `0666` minus umask).
🎯 Impact: Sensitive files could become world-readable, and executable scripts/binaries could lose their executable bit, leading to operational failures or security risks.
🔧 Fix: Updated `replaceInFile`, `copyFile`, and `copyDir` to use `os.Lstat` to capture the source file's mode and `os.OpenFile` with that mode to ensure permissions are preserved.
✅ Verification: Added unit tests in `internal/cli/permission_security_test.go` and verified they pass alongside existing tests.

---
*PR created automatically by Jules for task [8838530954628033144](https://jules.google.com/task/8838530954628033144) started by @DanteDev2102*