### PR TITLE
🛡️ Sentinel: Protect reserved 'config' section from deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2024-05-24 - Protection of Reserved Configuration Sections
+**Vulnerability:** Accidental or malicious deletion of the global 'config' section via the 'rm' command.
+**Learning:** Hardening a configuration parser involves not only validating new entries but also protecting existing reserved entries that hold application-level state or settings.
+**Prevention:** Implement explicit, case-insensitive checks in deletion and update operations to prevent modification of reserved keywords or sections.

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,12 +2,18 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if strings.ToLower(name) == "config" {
+		fmt.Println("Error: Cannot delete the reserved 'config' section.")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,48 @@ func TestWrite_Symlink(t *testing.T) {
 
 	if string(content) != "SENSITIVE DATA" {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := []byte("[config]\nauthor = \"Sentinel\"\n\n[test-template]\nrepo = \"https://github.com/test/repo\"\n")
+	err = os.WriteFile(configPath, initialContent, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: initialContent,
+	}
+
+	// Attempt to delete the "config" section
+	p.DeleteSection("config")
+
+	// Read the file back and verify "config" still exists
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "[config]") {
+		t.Errorf("Config section was deleted!")
+	}
+
+	// Attempt to delete with different case
+	p.DeleteSection("CONFIG")
+	data, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[config]") {
+		t.Errorf("Config section was deleted with case-insensitive check!")
 	}
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The 'rm' command allowed deleting the global '[config]' section.
🎯 Impact: Loss of global settings like 'author' and potential configuration corruption.
🔧 Fix: Added a case-insensitive guard in `DeleteSection` to reject 'config'.
✅ Verification: Added `TestDeleteSection_ConfigProtection` in `internal/parser/security_test.go`.

---
*PR created automatically by Jules for task [16863802023479071818](https://jules.google.com/task/16863802023479071818) started by @DanteDev2102*