### PR TITLE
🛡️ Sentinel: [MEDIUM] Protect reserved 'config' section from modification/deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-10 - Inconsistent Protection of Reserved Configuration Sections
+**Vulnerability:** Reserved sections (like `[config]`) could be modified or deleted via update (`set`) and delete (`rm`) commands, even if creation (`create`) had name validation.
+**Learning:** Security controls must be applied consistently across all data modification paths (Create, Update, Delete). Protecting only the entry point (creation) is insufficient if subsequent modification tools bypass those checks.
+**Prevention:** Centralize validation logic or ensure every function that modifies configuration state explicitly checks for reserved keys and forbidden operations on sensitive sections.

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,12 +2,18 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if strings.ToLower(name) == "config" {
+		fmt.Println("Error: The 'config' section is reserved and cannot be deleted.")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -3,7 +3,10 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestWrite_Symlink(t *testing.T) {
@@ -46,5 +49,98 @@ func TestWrite_Symlink(t *testing.T) {
 
 	if string(content) != "SENSITIVE DATA" {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "test-author"
+
+[template1]
+repo = "https://github.com/test/repo"`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	// Populate p.Content
+	_, err = p.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to delete the "config" section
+	p.DeleteSection("config")
+
+	// Read content back
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "[config]") {
+		t.Error("The [config] section was deleted, but it should be protected!")
+	}
+}
+
+func TestWriteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-write-section-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "test-author"
+
+[template1]
+repo = "https://github.com/test/repo"`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	// Populate p.Content
+	_, err = p.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to modify the "config" section via WriteSection
+	tmpl := &Template{
+		Author: "malicious-author",
+	}
+	p.WriteSection(tmpl, "config")
+
+	// Read content back and check author
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]interface{}
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if configMap, ok := config["config"].(map[string]interface{}); ok {
+		if author, ok := configMap["author"].(string); ok && author == "malicious-author" {
+			t.Error("The [config] section was modified, but it should be protected from direct updates!")
+		}
 	}
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -76,6 +77,11 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	if strings.ToLower(name) == "config" {
+		fmt.Println("Error: The 'config' section is reserved and cannot be modified directly.")
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)


### PR DESCRIPTION
Protect the reserved `[config]` section in `repositories.toml` from being modified or deleted via CLI commands. This ensures global configuration remains intact even if a user attempts to name a template 'config' or specifically target that section with `set` or `rm`.

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Logic-level bypass of reserved section protection.
### 🎯 Impact: Potential for global configuration corruption or deletion.
### 🔧 Fix: Implemented case-insensitive validation for the "config" key in both `DeleteSection` and `WriteSection` methods.
### ✅ Verification: New security tests in `internal/parser/security_test.go` confirm that attempts to modify or delete the "config" section are rejected.

---
*PR created automatically by Jules for task [5724021390873101065](https://jules.google.com/task/5724021390873101065) started by @DanteDev2102*