### PR TITLE
🛡️ Sentinel: [MEDIUM] Protect reserved config section from deletion/overwrite

### DIFF
--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,12 +2,19 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	// Security check: Prevent deletion of the reserved [config] section
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: The [config] section cannot be deleted")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,48 @@ func TestWrite_Symlink(t *testing.T) {
 
 	if string(content) != "SENSITIVE DATA" {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	configContent := `[config]
+author = "test-author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(configContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	p.Refresh()
+
+	// Attempt to delete the config section
+	p.DeleteSection("config")
+
+	// Verify the config section still exists
+	p.Refresh()
+	// Note: ExtractCommands handles [config] specially and puts it in p.Config,
+	// but it shouldn't be in p.Commmands.
+	// Let's check the raw content instead to be sure.
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "[config]") {
+		t.Error("The [config] section was deleted despite protection!")
 	}
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -76,6 +77,12 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	// Security check: Prevent updating the reserved [config] section
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: The [config] section cannot be updated directly")
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability:
The `[config]` section in the `repositories.toml` configuration file, which stores global settings like the default `author`, was not protected from being deleted or overwritten via the CLI's `rm` or `set` commands.

### 🎯 Impact:
An accidental or malicious operation could delete or corrupt the global configuration, leading to unexpected behavior in project initialization (e.g., losing the default author setting) or requiring manual repair of the configuration file.

### 🔧 Fix:
- Modified `internal/parser/delete.go`: Added a case-insensitive check to `DeleteSection` to prevent removing the "config" section.
- Modified `internal/parser/write.go`: Added a case-insensitive check to `WriteSection` to prevent updating the "config" section directly.
- Note: New template creation and renaming are already protected by `ValidateTemplateName`.

### ✅ Verification:
- Added `TestDeleteSection_ConfigProtection` in `internal/parser/security_test.go` which confirms the `[config]` section persists after an attempted deletion.
- Ran `go test ./...` and all tests passed.

---
*PR created automatically by Jules for task [2775818548256378245](https://jules.google.com/task/2775818548256378245) started by @DanteDev2102*