### PR TITLE
🛡️ Sentinel: [HIGH] Protect reserved config section and validate URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2025-01-24 - Bypass of Reserved Section Protection in Update/Delete Commands
+**Vulnerability:** The `[config]` section could be deleted or modified via the `rm` and `set` commands because validation only checked the *new* name, not the *target* name.
+**Learning:** Security validation must be applied to all operations (Create, Update, Delete) that target protected resources by name, not just at the point of creation.
+**Prevention:** Explicitly check for reserved words in all functions that accept a section or key name as input, regardless of whether it's a new or existing entry.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/DanteDev2102/Glyph/config"
+	"github.com/DanteDev2102/Glyph/internal/gitutils"
 	"github.com/DanteDev2102/Glyph/internal/parser"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +17,14 @@ func (cli *Base) UpdateCmd() {
 		Long:  config.SetDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if repo != "" {
+				_, err := gitutils.ValidateRepo(repo)
+				if err != nil {
+					fmt.Printf("Error validating repository: %v\n", err)
+					return
+				}
+			}
+
 			cli.Conf.WriteSection(&parser.Template{
 				Name:        name,
 				Repo:        repo,

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -19,6 +20,11 @@ func (p *Parser) DeleteSection(name string) {
 	_, ok := config[name]
 	if !ok {
 		fmt.Println("Not Exist this command")
+		return
+	}
+
+	if strings.ToLower(name) == "config" {
+		fmt.Println("Error: [config] section is reserved and cannot be deleted.")
 		return
 	}
 

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,83 @@ func TestWrite_Symlink(t *testing.T) {
 
 	if string(content) != "SENSITIVE DATA" {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "test-author"
+
+[template1]
+repo = "https://github.com/test/repo1"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Try to delete the config section
+	p.DeleteSection("config")
+
+	// Read the file back
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "[config]") {
+		t.Errorf("Critical vulnerability: [config] section was deleted!")
+	}
+}
+
+func TestWriteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "test-author"
+
+[template1]
+repo = "https://github.com/test/repo1"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Try to modify the config section
+	p.WriteSection(&Template{
+		Repo: "https://github.com/malicious/repo",
+	}, "config")
+
+	// Read the file back
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(data), "https://github.com/malicious/repo") {
+		t.Errorf("Critical vulnerability: [config] section was modified!")
 	}
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -94,6 +95,11 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	_, ok := config[name]
 	if !ok {
 		fmt.Println("Not Exist this command")
+		return
+	}
+
+	if strings.ToLower(name) == "config" {
+		fmt.Println("Error: [config] section is reserved and cannot be modified.")
 		return
 	}
 


### PR DESCRIPTION
This PR addresses a vulnerability where the reserved `[config]` section could be deleted or overwritten via CLI commands. It also enhances the `set` command by adding repository URL validation, consistent with the `create` command. Unit tests are included to verify these protections.

---
*PR created automatically by Jules for task [16669964032333008953](https://jules.google.com/task/16669964032333008953) started by @DanteDev2102*