### PR TITLE
🛡️ Sentinel: Harden configuration parser security

### DIFF
--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -8,6 +8,11 @@ import (
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if err := ValidateTemplateName(name); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestWrite_Symlink(t *testing.T) {
@@ -46,5 +48,133 @@ func TestWrite_Symlink(t *testing.T) {
 
 	if string(content) != "SENSITIVE DATA" {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
+	}
+}
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-vulnerability-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Original Author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Attempt to delete the [config] section
+	p.DeleteSection("config")
+
+	// Read back the file
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]interface{}
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := config["config"]; !ok {
+		t.Error("config section was deleted! (Vulnerable)")
+	}
+}
+
+func TestWriteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-vulnerability-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Original Author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Attempt to modify the [config] section
+	tmpl := &Template{
+		Author: "Hacker",
+	}
+	p.WriteSection(tmpl, "config")
+
+	// Read back the file
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]map[string]string
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c, ok := config["config"]; ok {
+		if c["author"] == "Hacker" {
+			t.Error("config section was modified! (Vulnerable)")
+		}
+	} else {
+		t.Error("config section was removed or renamed! (Vulnerable)")
+	}
+}
+
+func TestMkdirPermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-perm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configDir := filepath.Join(tmpDir, "config")
+	configPath := filepath.Join(configDir, "repositories.toml")
+
+	p := &Parser{
+		File: configPath,
+	}
+
+	tmpl := &Template{
+		Name: "test-template",
+		Repo: "https://github.com/test/repo",
+	}
+
+	// This should call os.MkdirAll(dir, 0700)
+	p.Write(tmpl)
+
+	info, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mode := info.Mode().Perm()
+	if mode != 0700 {
+		t.Errorf("Config directory has incorrect permissions: %v, expected 0700", mode)
 	}
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,7 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -76,6 +76,11 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	if err := ValidateTemplateName(name); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)
@@ -153,7 +158,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability
The configuration parser allowed modification or deletion of reserved sections like `[config]` via the `WriteSection` and `DeleteSection` methods. Additionally, the configuration directory was created with overly permissive `0755` permissions.

### 🎯 Impact
Unauthorized or accidental deletion/modification of the `[config]` section could disrupt application settings (e.g., global author name). Permissive directory permissions could allow other local users to read sensitive repository configuration.

### 🔧 Fix
1.  Added calls to `ValidateTemplateName(name)` at the beginning of `DeleteSection` and `WriteSection` to block operations on reserved words.
2.  Updated `os.MkdirAll` calls in `internal/parser/write.go` to use `0700` permissions.

### ✅ Verification
Consolidated security tests into `internal/parser/security_test.go`:
- `TestDeleteSection_ConfigProtection` verifies that the `config` section cannot be deleted.
- `TestWriteSection_ConfigProtection` verifies that the `config` section cannot be modified.
- `TestMkdirPermissions` verifies that the configuration directory is created with `0700` permissions.
Ran `go test ./...` and all tests passed.

---
*PR created automatically by Jules for task [15446245595676880332](https://jules.google.com/task/15446245595676880332) started by @DanteDev2102*