### PR TITLE
🛡️ Sentinel: [MEDIUM] Hardened configuration and file permissions

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -99,7 +99,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {

--- a/internal/cli/permission_security_test.go
+++ b/internal/cli/permission_security_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceInFile_PreservePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "testfile")
+	// Create file with restricted permissions
+	err = os.WriteFile(testFile, []byte("Hello {{.ProjectName}}"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacements := map[string]string{"ProjectName": "Test"}
+	replaceInFile(testFile, replacements)
+
+	info, err := os.Stat(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Permissions not preserved! Expected 0600, got %o", info.Mode().Perm())
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "Hello Test" {
+		t.Errorf("Content not replaced! Expected 'Hello Test', got '%s'", string(content))
+	}
+}

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,8 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	if err := os.WriteFile(p.File, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/security_test.go
+++ b/internal/parser/security_test.go
@@ -48,3 +48,36 @@ func TestWrite_Symlink(t *testing.T) {
 		t.Errorf("Target file was modified through symlink! Content: %s", string(content))
 	}
 }
+
+func TestSafeWrite_EnforcePermissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	// Pre-create file with overly permissive permissions
+	err = os.WriteFile(configPath, []byte("old data"), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+
+	err = p.safeWrite([]byte("new data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("Permissions not enforced! Expected 0600, got %o", info.Mode().Perm())
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,8 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	// Security check: Use restricted permissions (0700) for the configuration directory
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -153,7 +154,8 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	// Security check: Use restricted permissions (0700) for the configuration directory
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability:
Overly permissive default directory permissions (0755) for the configuration directory and lack of explicit permission enforcement for the configuration file if it already existed with broader permissions. Also, potential permission regression during variable replacement in project files.

### 🎯 Impact:
On multi-user systems, sensitive configuration data (like template locations or potential future secrets) could be readable by other users. File permissions (like executable bits) could be lost during project initialization.

### 🔧 Fix:
1.  **Restricted Directory Permissions:** Changed `os.MkdirAll` to use `0700` for the configuration directory in `internal/parser/write.go`.
2.  **Enforced File Permissions:** Added an explicit `os.Chmod(p.File, 0600)` in `internal/parser/main.go`'s `safeWrite` method to ensure the configuration file is restricted even if it previously had broader permissions.
3.  **Preserved File Permissions:** Updated `replaceInFile` in `internal/cli/init.go` to use the original file's permissions when writing back modified content.

### ✅ Verification:
-   Added `TestSafeWrite_EnforcePermissions` in `internal/parser/security_test.go`.
-   Added `TestReplaceInFile_PreservePermissions` in `internal/cli/permission_security_test.go`.
-   Ran `go test ./...` and verified all tests pass.
-   Manually verified that `go build` succeeds.

---
*PR created automatically by Jules for task [13514519543275729959](https://jules.google.com/task/13514519543275729959) started by @DanteDev2102*