### PR TITLE
🛡️ Sentinel: [MEDIUM] Protect reserved 'config' section from modification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-10 - Reserved Configuration Section Protection
+**Vulnerability:** The reserved `[config]` section could be modified or deleted via the `set` and `rm` CLI commands by targeting it by name.
+**Learning:** Protecting reserved keywords during resource creation is insufficient if existing resources can still be manipulated by the same reserved names.
+**Prevention:** Implement explicit, case-insensitive protection for reserved keywords in all data-layer methods that perform updates or deletions on named configuration sections.

--- a/internal/parser/config_protection_test.go
+++ b/internal/parser/config_protection_test.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestConfigSectionProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-config-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialConfig := `[config]
+author = "original-author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialConfig), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{File: configPath}
+	_ = p.ExtractCommands()
+
+	t.Run("WriteSection Protection", func(t *testing.T) {
+		p.WriteSection(&Template{Author: "malicious"}, "config")
+		p.Refresh()
+		var data map[string]interface{}
+		content, _ := os.ReadFile(configPath)
+		_ = toml.Unmarshal(content, &data)
+		configSection := data["config"].(map[string]interface{})
+		if configSection["author"] == "malicious" {
+			t.Error("Vulnerability: config section modified")
+		}
+	})
+
+	t.Run("DeleteSection Protection", func(t *testing.T) {
+		p.DeleteSection("config")
+		p.Refresh()
+		var data map[string]interface{}
+		content, _ := os.ReadFile(configPath)
+		_ = toml.Unmarshal(content, &data)
+		if _, ok := data["config"]; !ok {
+			t.Error("Vulnerability: config section deleted")
+		}
+	})
+}

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -13,6 +14,11 @@ func (p *Parser) DeleteSection(name string) {
 	err := toml.Unmarshal(p.Content, &config)
 	if err != nil {
 		fmt.Println(err)
+		return
+	}
+
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Cannot delete reserved 'config' section")
 		return
 	}
 

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -88,6 +89,11 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	err := toml.Unmarshal(p.Content, &config)
 	if err != nil {
 		fmt.Println(err)
+		return
+	}
+
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Cannot modify reserved 'config' section")
 		return
 	}
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Protect reserved 'config' section from modification

Vulnerability: The `[config]` section in `repositories.toml`, which stores global tool settings, was vulnerable to being modified or deleted by CLI commands if a user or malicious template targeted it by name.

Impact: Unauthorized modification of tool settings or configuration corruption.

Fix:
- Added `strings.EqualFold(name, "config")` checks in `WriteSection` and `DeleteSection` to explicitly reject operations on the reserved section.
- Added a comprehensive unit test to verify protection for both modification and deletion.
- Updated the Sentinel journal with the learning.

Verification:
- Created and ran `internal/parser/config_protection_test.go`.
- Ran the full test suite (`go test ./...`).
- Verified that the "config" section remains intact after attempting to modify it via the parser.

---
*PR created automatically by Jules for task [6323329703108136797](https://jules.google.com/task/6323329703108136797) started by @DanteDev2102*