### PR TITLE
🛡️ Sentinel: [security improvement] Protect reserved [config] section in parser

### DIFF
--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -3,11 +3,18 @@ package parser
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: the [config] section cannot be deleted")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/delete_security_test.go
+++ b/internal/parser/delete_security_test.go
@@ -1,0 +1,46 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"strings"
+)
+
+func TestDeleteSection_Config(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Original Author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Attempt to delete the [config] section
+	p.DeleteSection("config")
+
+	// Verify the [config] section still exists
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "[config]") {
+		t.Error("[config] section was deleted!")
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -76,6 +77,11 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	if strings.EqualFold(name, "config") || strings.EqualFold(tmpl.Name, "config") {
+		fmt.Println("Error: the [config] section cannot be overwritten or used as a template name")
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)

--- a/internal/parser/write_security_test.go
+++ b/internal/parser/write_security_test.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"strings"
+)
+
+func TestWriteSection_Config(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-write-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Original Author"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: []byte(initialContent),
+	}
+
+	// Attempt to modify the [config] section using WriteSection
+	p.WriteSection(&Template{
+		Repo: "https://evil.com/repo",
+	}, "config")
+
+	// Verify the [config] section was not corrupted or overwritten with template fields
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Currently, WriteSection will fail to unmarshal if [config] has different structure
+	// Let's see what happened
+	t.Logf("Config content after WriteSection:\n%s", string(content))
+
+	if strings.Contains(string(content), "repo = \"https://evil.com/repo\"") && strings.Contains(string(content), "[config]") {
+		t.Error("[config] section was overwritten with template fields!")
+	}
+}


### PR DESCRIPTION
Implemented safeguards in the parser to protect the reserved `[config]` section from being deleted, overwritten, or modified with template fields. Used `strings.EqualFold` for case-insensitive protection. Added unit tests to verify the security enhancement and prevent regressions.

---
*PR created automatically by Jules for task [10730707271986541511](https://jules.google.com/task/10730707271986541511) started by @DanteDev2102*