### PR TITLE
🛡️ Sentinel: Harden configuration protection and permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-06-18 - Strict Configuration Permission Enforcement
+**Vulnerability:** Configuration file permissions could be broader than intended if the file already existed. `os.WriteFile` with `0600` does not change permissions of an existing file.
+**Learning:** In Go, `os.WriteFile` (and similar calls using `O_TRUNC`) only applies the mode bits during file creation. It does not downgrade permissions of an existing file, which can lead to sensitive configuration remaining world-readable.
+**Prevention:** Always follow a write operation with an explicit `os.Chmod` when strictly restricted permissions (e.g., 0600) are required for information protection.

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,12 +2,19 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	// Security check: Don't allow deleting the reserved [config] section
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: Cannot delete the reserved 'config' section")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/delete_security_test.go
+++ b/internal/parser/delete_security_test.go
@@ -1,0 +1,83 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestDeleteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := []byte("[config]\nauthor = \"test-author\"\n\n[my-template]\nrepo = \"some-repo\"\n")
+	err = os.WriteFile(configPath, initialContent, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: initialContent,
+	}
+
+	// Try to delete the 'config' section (should currently succeed, but we want it to fail after hardening)
+	p.DeleteSection("config")
+
+	// Read back the file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]interface{}
+	err = toml.Unmarshal(data, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := config["config"]; !ok {
+		t.Errorf("Config section was deleted! Protection is missing.")
+	}
+}
+
+func TestDeleteSection_CaseInsensitiveConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-case-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := []byte("[config]\nauthor = \"test-author\"\n")
+	err = os.WriteFile(configPath, initialContent, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: initialContent,
+	}
+
+	// Try to delete 'CONFIG' (case-insensitive)
+	p.DeleteSection("CONFIG")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]interface{}
+	toml.Unmarshal(data, &config)
+
+	if _, ok := config["config"]; !ok {
+		t.Errorf("Config section was deleted using uppercase 'CONFIG'! Case-insensitive protection is missing.")
+	}
+}

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,11 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	err := os.WriteFile(p.File, data, 0600)
+	if err != nil {
+		return err
+	}
+
+	// Security check: Explicitly enforce 0600 permissions even if the file existed
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -64,7 +65,8 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	// Security check: Use restricted permissions for the config directory
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -76,6 +78,12 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	// Security check: Don't allow modifying the reserved [config] section
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: Cannot modify the reserved 'config' section")
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)
@@ -153,7 +161,8 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	// Security check: Use restricted permissions for the config directory
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {

--- a/internal/parser/write_security_test.go
+++ b/internal/parser/write_security_test.go
@@ -1,0 +1,90 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestWriteSection_ConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-write-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := []byte("[config]\nauthor = \"original-author\"\n")
+	err = os.WriteFile(configPath, initialContent, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: initialContent,
+	}
+
+	tmpl := &Template{
+		Author: "malicious-author",
+	}
+
+	// Try to modify 'config' using WriteSection
+	p.WriteSection(tmpl, "config")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]map[string]string
+	err = toml.Unmarshal(data, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if author, ok := config["config"]["author"]; ok && author == "malicious-author" {
+		t.Errorf("Config section was modified! Protection for WriteSection is missing.")
+	}
+}
+
+func TestWriteSection_CaseInsensitiveConfigProtection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-write-case-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := []byte("[config]\nauthor = \"original-author\"\n")
+	err = os.WriteFile(configPath, initialContent, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File:    configPath,
+		Content: initialContent,
+	}
+
+	tmpl := &Template{
+		Author: "malicious-author",
+	}
+
+	// Try to modify 'CONFIG' using WriteSection
+	p.WriteSection(tmpl, "CONFIG")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]map[string]string
+	toml.Unmarshal(data, &config)
+
+	if author, ok := config["config"]["author"]; ok && author == "malicious-author" {
+		t.Errorf("Config section was modified using uppercase 'CONFIG'! Case-insensitive protection for WriteSection is missing.")
+	}
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Harden configuration protection and permissions

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: 
1. The reserved `[config]` section (containing global settings like `author`) could be deleted or modified via the `rm` and `set` commands.
2. Configuration file permissions could be overly permissive (e.g., 0644) if the file already existed, as `os.WriteFile` does not downgrade permissions.
3. The configuration directory was created with 0755 permissions.

### 🎯 Impact:
1. Unauthorized modification or deletion of global configuration could disrupt the tool's behavior or misrepresent the project author.
2. Sensitive configuration data (if added in the future) could be read by other users on the system.

### 🔧 Fix:
- Added case-insensitive checks in `DeleteSection` and `WriteSection` to reject operations on the "config" section.
- Added an explicit `os.Chmod(..., 0600)` call in `safeWrite` to strictly enforce permissions.
- Hardened `os.MkdirAll` calls to use `0700` for the configuration directory.

### ✅ Verification:
- Created and ran new security tests in `internal/parser/delete_security_test.go` and `internal/parser/write_security_test.go`.
- Verified that all existing tests pass with `go test ./...`.


---
*PR created automatically by Jules for task [574445545587710522](https://jules.google.com/task/574445545587710522) started by @DanteDev2102*