### PR TITLE
🛡️ Sentinel: Harden configuration permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-04-07 - Enforcement of Restrictive Configuration Permissions
+**Vulnerability:** Configuration files and directories could maintain overly permissive permissions (e.g., 0644) if they pre-existed, as os.WriteFile and os.MkdirAll do not override modes on existing paths.
+**Learning:** Hardening existing files requires an explicit os.Chmod call. However, when hardening parent directories using filepath.Dir, safety checks are mandatory to prevent unintended permission changes to the current working directory (.) or root (/).
+**Prevention:** Use os.Chmod(path, 0600) for files and os.Chmod(dir, 0700) for directories, with explicit exclusions for "." and "/" when deriving parent paths.

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,9 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	if err := os.WriteFile(p.File, data, 0600); err != nil {
+		return err
+	}
+
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/permissions_security_test.go
+++ b/internal/parser/permissions_security_test.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissions_FileHardening(t *testing.T) {
+	tmpDir := t.TempDir()
+	confFile := filepath.Join(tmpDir, "repositories.toml")
+
+	// Pre-create file with broad permissions
+	if err := os.WriteFile(confFile, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{File: confFile}
+	if err := p.safeWrite([]byte("test content")); err != nil {
+		t.Fatalf("safeWrite failed: %v", err)
+	}
+
+	info, err := os.Stat(confFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600, got %v", info.Mode().Perm())
+	}
+}
+
+func TestPermissions_DirectoryHardening(t *testing.T) {
+	tmpDir := t.TempDir()
+	confDir := filepath.Join(tmpDir, ".config", "Glyph")
+	confFile := filepath.Join(confDir, "repositories.toml")
+
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{File: confFile}
+	p.Write(&Template{Name: "test"})
+
+	info, err := os.Stat(confDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("expected 0700, got %v", info.Mode().Perm())
+	}
+}
+
+func TestPermissions_NoChmodOnCWD(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalWd)
+
+	// Current directory should have 0755 or similar (usually restricted by umask)
+	// We'll set it to 0755 explicitly to test
+	if err := os.Chmod(".", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{File: "repositories.toml"}
+	p.Write(&Template{Name: "test"})
+
+	info, _ := os.Stat(".")
+	if info.Mode().Perm() == 0700 {
+		t.Error("safeWrite should not chmod the current directory")
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -65,6 +65,9 @@ func (p *Parser) Write(tmpl *Template) {
 
 	dir := filepath.Dir(p.File)
 	os.MkdirAll(dir, 0755)
+	if dir != "." && dir != "/" {
+		os.Chmod(dir, 0700)
+	}
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -154,6 +157,9 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 
 	dir := filepath.Dir(p.File)
 	os.MkdirAll(dir, 0755)
+	if dir != "." && dir != "/" {
+		os.Chmod(dir, 0700)
+	}
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Configuration files and directories could maintain overly permissive permissions (e.g., 0644) if they pre-existed, as os.WriteFile and os.MkdirAll do not override modes on existing paths.
🎯 Impact: Unauthorized local users could potentially read sensitive configuration data or project templates.
🔧 Fix: Explicitly call os.Chmod(0600) for the config file and os.Chmod(0700) for its parent directory, with safety checks to avoid modifying the current working directory or root.
✅ Verification: New security tests in `internal/parser/permissions_security_test.go` verify hardening of pre-existing files/directories and ensure no accidental modification of the current directory.

---
*PR created automatically by Jules for task [14923208544758358541](https://jules.google.com/task/14923208544758358541) started by @DanteDev2102*