### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden configuration file and directory permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,8 +20,8 @@
 
 ## 2026-04-12 - Secure Configuration File Permissions
 **Vulnerability:** Configuration file created with world-readable permissions (0644).
-**Learning:** Default file creation permissions in many languages/environments are overly permissive for configuration files that may contain sensitive user information or preferences.
-**Prevention:** Explicitly set restricted permissions (e.g., 0600) when creating or writing to configuration files to ensure only the owner can access them.
+**Learning:** Default file creation permissions in many languages/environments are overly permissive for configuration files. In Go, `os.WriteFile` with restricted permissions (0600) will NOT change the permissions of an existing file that has broader permissions (e.g., 0644).
+**Prevention:** Always use an explicit `os.Chmod(path, 0600)` after writing to ensure restricted permissions are enforced regardless of the file's previous state. Use `0700` for the containing directory.
 
 ## 2026-05-15 - Template Name Validation
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.

--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -49,5 +49,11 @@ func (p *Parser) safeWrite(data []byte) error {
 		}
 	}
 
-	return os.WriteFile(p.File, data, 0600)
+	err := os.WriteFile(p.File, data, 0600)
+	if err != nil {
+		return err
+	}
+
+	// Explicitly set permissions to 0600 in case the file already existed with broader permissions.
+	return os.Chmod(p.File, 0600)
 }

--- a/internal/parser/permissions_security_test.go
+++ b/internal/parser/permissions_security_test.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPermissions_FileAndDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-perm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "Glyph")
+	configPath := filepath.Join(configDir, "repositories.toml")
+
+	p := &Parser{
+		File: configPath,
+	}
+
+	tmpl := &Template{
+		Name: "test-template",
+		Repo: "https://github.com/test/repo",
+	}
+
+	// 1. Test Directory Permissions
+	p.Write(tmpl)
+
+	dirInfo, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expecting 0700 (drwx------)
+	if dirInfo.Mode().Perm() != 0700 {
+		t.Errorf("Config directory has insecure permissions: %v, expected 0700", dirInfo.Mode().Perm())
+	}
+
+	// 2. Test File Permissions Hardening (Existing File)
+	// Reset: Delete file and create with loose permissions
+	os.Remove(configPath)
+	err = os.WriteFile(configPath, []byte("existing data"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it is 0644
+	fileInfo, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileInfo.Mode().Perm() != 0644 {
+		t.Fatalf("Setup failed: file is not 0644, it is %v", fileInfo.Mode().Perm())
+	}
+
+	// Call Write (which calls safeWrite)
+	p.Content = []byte("") // reset content to avoid unmarshal error or use Refresh/ensureContentRead
+	p.ContentRead = false
+	p.Write(tmpl)
+
+	// Check permissions again
+	fileInfo, err = os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expecting 0600 (rw-------)
+	if fileInfo.Mode().Perm() != 0600 {
+		t.Errorf("Config file permissions were not hardened: %v, expected 0600", fileInfo.Mode().Perm())
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -64,7 +64,7 @@ func (p *Parser) Write(tmpl *Template) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	if err := p.safeWrite(data); err != nil {
 		fmt.Println(err)
@@ -153,7 +153,7 @@ func (p *Parser) WriteSection(tmpl *Template, name string) {
 	}
 
 	dir := filepath.Dir(p.File)
-	os.MkdirAll(dir, 0755)
+	os.MkdirAll(dir, 0700)
 
 	err = p.safeWrite(data)
 	if err != nil {


### PR DESCRIPTION
Hardened the configuration persistence layer by enforcing restricted directory (0700) and file (0600) permissions. Included a new security test to verify the fix and updated the sentinel journal with learnings about Go's `os.WriteFile` permission handling.

---
*PR created automatically by Jules for task [1754066396547024911](https://jules.google.com/task/1754066396547024911) started by @DanteDev2102*