### PR TITLE
🛡️ Sentinel: Protect reserved [config] section from modification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Lack of validation for template names could lead to configuration corruption (e.g., overwriting the `[config]` section) or CLI command shadowing.
 **Learning:** User-provided keys in a configuration file that also dictate CLI subcommands must be strictly validated against a whitelist of characters and a blacklist of reserved words.
 **Prevention:** Enforce strict naming conventions (alphanumeric, hyphens, underscores) and reject reserved keywords used by the application's configuration or CLI framework.
+
+## 2026-04-09 - Protection of Reserved Configuration Sections
+**Vulnerability:** Modification or deletion of the reserved `[config]` section via CLI commands. While creation was protected, existing sections could still be targeted by `rm` or `set`.
+**Learning:** Security validations for reserved resources must be implemented at every modification point (delete, update, rename), not just at creation time.
+**Prevention:** Use case-insensitive validation (`strings.EqualFold`) to protect reserved keywords at all operational entry points that modify configuration state.

--- a/internal/parser/delete.go
+++ b/internal/parser/delete.go
@@ -2,12 +2,18 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // DeleteSection removes a section from the configuration by its name.
 func (p *Parser) DeleteSection(name string) {
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: [config] section cannot be deleted as it is reserved for global settings")
+		return
+	}
+
 	var config map[string]interface{}
 
 	err := toml.Unmarshal(p.Content, &config)

--- a/internal/parser/delete_security_test.go
+++ b/internal/parser/delete_security_test.go
@@ -1,0 +1,95 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestDeleteSection_ProtectConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Sentinel"
+
+[test-template]
+repo = "https://github.com/test/repo"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	err = p.ExtractCommands()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to delete the config section
+	p.DeleteSection("config")
+
+	// Verify if config section still exists
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var data map[string]interface{}
+	err = toml.Unmarshal(content, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := data["config"]; !ok {
+		t.Errorf("Critical vulnerability: [config] section was deleted!")
+	}
+}
+
+func TestDeleteSection_ProtectConfigCaseInsensitive(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-delete-ci-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Sentinel"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	err = p.ExtractCommands()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to delete the config section with different casing
+	p.DeleteSection("CONFIG")
+
+	// Verify if config section still exists
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(content), "[config]") && !strings.Contains(string(content), "[CONFIG]") {
+		t.Errorf("Critical vulnerability: [config] section was deleted via case-insensitive match!")
+	}
+}

--- a/internal/parser/write.go
+++ b/internal/parser/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -76,6 +77,11 @@ func (p *Parser) Write(tmpl *Template) {
 
 // WriteSection updates or adds a section in the TOML configuration based on the provided template and section name.
 func (p *Parser) WriteSection(tmpl *Template, name string) {
+	if strings.EqualFold(name, "config") {
+		fmt.Println("Error: [config] section cannot be modified via this command as it is reserved for global settings")
+		return
+	}
+
 	if tmpl.Name != "" {
 		if err := ValidateTemplateName(tmpl.Name); err != nil {
 			fmt.Printf("Error: %v\n", err)

--- a/internal/parser/write_security_test.go
+++ b/internal/parser/write_security_test.go
@@ -1,0 +1,108 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestWriteSection_ProtectConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-write-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Sentinel"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	err = p.ExtractCommands()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := &Template{
+		Name:   "hacker-config",
+		Author: "Malicious",
+	}
+
+	// Try to rename [config] to [hacker-config]
+	p.WriteSection(tmpl, "config")
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var data map[string]interface{}
+	err = toml.Unmarshal(content, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := data["config"]; !ok {
+		t.Errorf("Critical vulnerability: [config] section was renamed or removed via WriteSection!")
+	}
+
+	// Check if it was overwritten with template fields (config should only have 'author' from the Config struct, not template fields like 'repo')
+	// Wait, WriteSection unmarshals into map[string]map[string]string, which might break the [config] section structure anyway.
+}
+
+func TestWriteSection_ProtectConfigCaseInsensitive(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "glyph-parser-write-ci-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "repositories.toml")
+	initialContent := `[config]
+author = "Sentinel"
+`
+	err = os.WriteFile(configPath, []byte(initialContent), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Parser{
+		File: configPath,
+	}
+	err = p.ExtractCommands()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := &Template{
+		Author: "Malicious",
+	}
+
+	// Try to modify [config] using "CONFIG"
+	p.WriteSection(tmpl, "CONFIG")
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var data map[string]interface{}
+	err = toml.Unmarshal(content, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := data["config"]; !ok {
+		// If it's not under "config", maybe it was renamed to something else or lost
+		t.Errorf("Critical vulnerability: [config] section was modified/removed via case-insensitive WriteSection!")
+	}
+}


### PR DESCRIPTION
I have implemented protection for the reserved `[config]` section in the `repositories.toml` configuration file. Previously, while the `create` command prevented naming new templates as `config`, the `rm` and `set` commands could still target the existing `[config]` section, leading to potential data loss or configuration corruption of global settings like the default author.

I added case-insensitive checks in `DeleteSection` and `WriteSection` to ensure this section remains intact and is only managed through appropriate channels. I also added unit tests to verify these protections.

---
*PR created automatically by Jules for task [1184014535843402423](https://jules.google.com/task/1184014535843402423) started by @DanteDev2102*