### PR TITLE
🛡️ Sentinel: [Enhancement] Preserve file permissions during initialization

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,7 +50,7 @@ func copyDir(src string, dst string) error {
 		}
 		defer srcFile.Close()
 
-		dstFile, err := os.Create(target)
+		dstFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func replaceInFile(filePath string, replacements map[string]string) {
 		s = strings.ReplaceAll(s, "{{."+k+"}}", v)
 	}
 
-	os.WriteFile(filePath, []byte(s), 0644)
+	os.WriteFile(filePath, []byte(s), info.Mode().Perm())
 }
 
 func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Command) {
@@ -219,16 +219,19 @@ func chargeTemplates(cli *Base, initCmd *cobra.Command, commands *[]parser.Comma
 }
 
 func copyFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
 	// Security check: Reject symbolic links at the source to prevent information disclosure
-	if info, err := os.Lstat(src); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source %s is a symbolic link", src)
-		}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source %s is a symbolic link", src)
 	}
 
 	// Security check: Reject symbolic links at the destination to prevent arbitrary file overwrites
-	if info, err := os.Lstat(dst); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
+	if dstInfo, err := os.Lstat(dst); err == nil {
+		if dstInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("destination %s is a symbolic link", dst)
 		}
 	}
@@ -239,7 +242,7 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: File permissions (such as executable bits or restricted access) were not preserved during template initialization, as `os.Create` and hardcoded `0644` were used.
🎯 Impact: Templates could lose critical executable bits, or sensitive files could become world-readable if they were originally intended to be restricted.
🔧 Fix: Updated the initialization logic to retrieve the source file's mode via `os.Lstat` and apply it to the destination file using `os.OpenFile` and `os.WriteFile`.
✅ Verification: Verified with a test case ensuring that `0700` (executable) and `0600` (private) permissions are correctly maintained through cloning and variable replacement.

---
*PR created automatically by Jules for task [9468924390698510501](https://jules.google.com/task/9468924390698510501) started by @DanteDev2102*